### PR TITLE
fix(darwin): file-read-metadata not file-read* for traversal

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -342,12 +342,13 @@ let
          /private/var/db/timezone — so date/time formatting works.
 
        Filesystem traversal (stat on parent dirs):
-         Allows stat() on /, /var, /private, /private/var, /Users,
-         $HOME, and $REPO_ROOT_PARENT. These are
-         read-only and restricted to literal paths (not subpath).
-         Needed because path resolution walks each component — without
-         this, even accessing an allowed subpath can fail with EPERM
-         during the stat() of a parent directory.
+         "/" gets file-read* (process startup requires readdir on root).
+         All others — /var, /private, /private/var, /Users,
+         $REAL_HOME, $REPO_ROOT_PARENT — get file-read-metadata only
+         (literal paths, not subpath). This allows stat() for path
+         component traversal without exposing directory contents via
+         readdir(). Without at least metadata access, even reaching an
+         allowed subpath can fail with EPERM during traversal.
 
        Working directory & repo:
          $CWD (subpath)        — full read-write to the project

--- a/lib/seatbelt-profile.nix
+++ b/lib/seatbelt-profile.nix
@@ -108,9 +108,12 @@
     (literal "/nix/store"))
   (allow file-read* (subpath "/nix/store"))
 
-  ;; Filesystem traversal — stat() on parent dirs for path resolution
-  (allow file-read*
-    (literal "/")
+  ;; Filesystem traversal — stat() on parent dirs for path resolution.
+  ;; "/" needs file-read* (process startup requires readdir on root).
+  ;; All other traversal paths use file-read-metadata so only stat() is
+  ;; allowed, preventing readdir() from enumerating directory contents.
+  (allow file-read* (literal "/"))
+  (allow file-read-metadata
     (literal "/var")
     (literal "/dev")
     (literal "/private")
@@ -119,14 +122,15 @@
     (literal "/private/etc")
     (literal "/private/var/db")
     (literal "/Users")
-    (literal (param "HOME"))
-    (subpath (param "HOME"))
     (literal (param "REAL_HOME"))
     (literal (param "HOME_LOCAL"))
     (literal (param "HOME_CACHE"))
     (literal (param "HOME_LOCAL_SHARE"))
     (literal (param "HOME_LOCAL_STATE"))
     (literal (param "REPO_ROOT_PARENT")))
+
+  ;; Sandbox HOME — full read access (it's an ephemeral tmpdir)
+  (allow file-read* (subpath (param "HOME")))
 
   ;; Working directory & repository
   (allow file-read* file-write* (subpath (param "CWD")))

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -62,6 +62,12 @@ if [ "$OS" = "Darwin" ]; then
 	expect_ok "can exec /bin/sh subshell" "/bin/sh -c 'echo hello'"
 	REAL_HOME="/Users/$(whoami)"
 	expect_fail "cannot read real home" "ls $REAL_HOME/.ssh"
+
+	# --- Directory enumeration (readdir blocked, stat allowed) ---
+	expect_fail "cannot enumerate /Users" "ls /Users/"
+	expect_fail "cannot enumerate real home dir" "ls $REAL_HOME/"
+	expect_ok "stat on /Users succeeds (path traversal)" "test -d /Users"
+	expect_ok "stat on real home succeeds (path traversal)" "test -d $REAL_HOME"
 elif [ "$OS" = "Linux" ]; then
 	expect_ok "/etc is writable tmpfs (ephemeral)" "touch /etc/test && rm /etc/test"
 	expect_fail "cannot read host /etc/shadow" "cat /etc/shadow"


### PR DESCRIPTION
Darwin: Disallow file-read* for directories only required for filesystem traversal. Use file-read-metadata* instead.