### PR TITLE
Prevent nix file changes in CWD

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -294,7 +294,6 @@ let
           --tmpfs "$HOME" \
           $REPO_BIND \
           --bind "$CWD" "$CWD" \
-          --ro-bind / / \
           "''${BWRAP_NIX_FILES[@]}" \
           ${bindDirsStr} \
           $STATE_FILE_BINDS \

--- a/default.nix
+++ b/default.nix
@@ -271,6 +271,12 @@ let
           BOUND_PREFIXES+=("$storePath")
         done < ${closurePathsFile}
 
+        # Build arguments for nix files in the current working directory
+        BWRAP_NIX_FILES=()
+        for f in "$CWD"/*.nix; do
+          [ -e "$f" ] && BWRAP_NIX_FILES+=(--bind /dev/null "$f")
+        done
+
         ${symlinkResolutionBashStr}
         ${conditionalNetworkingParams.proxyStartupBashStr}
         ${conditionalNetworkingParams.bashTrapCleanupStr}
@@ -288,6 +294,8 @@ let
           --tmpfs "$HOME" \
           $REPO_BIND \
           --bind "$CWD" "$CWD" \
+          --ro-bind / / \
+          "''${BWRAP_NIX_FILES[@]}" \
           ${bindDirsStr} \
           $STATE_FILE_BINDS \
           $SYMLINK_PARENT_DIRS \

--- a/lib/seatbelt-profile.nix
+++ b/lib/seatbelt-profile.nix
@@ -136,6 +136,7 @@
   (allow file-read* (subpath (param "REPO_ROOT")))
   (allow file-read* file-write* (subpath (param "GIT_DIR")))
   (allow file-read* (subpath (param "GIT_CONFIG_DIR")))
+  (deny file-read* (regex (string-append "^" (regex-quote (param "CWD")) "/[^/]*\\.nix$")))
 
   ;; Timezone
   (allow file-read* (subpath "/private/var/db/timezone"))

--- a/tests/shared/test-basic.sh
+++ b/tests/shared/test-basic.sh
@@ -2,6 +2,7 @@
 # Basic sandbox isolation and access tests (shared across platforms)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+echo "{}" >> test.nix
 
 source "$SCRIPT_DIR/../lib.sh"
 
@@ -24,6 +25,7 @@ echo
 expect_fail "cannot read ~/.ssh" "ls \$HOME/.ssh"
 expect_fail "cannot read ~/.bash_history" "cat \$HOME/.bash_history"
 expect_fail "cannot read /root" "ls /root"
+expect_fail "cannot read CWD *.nix files" "cat ./test.nix"
 
 # --- Basic access ---
 expect_ok "can write to CWD" "touch ./sandbox-test-file && rm ./sandbox-test-file"


### PR DESCRIPTION
Currently it's possible for a sandboxed executable to make changes to `flake.nix` - this means that a malicious prompt could adjust the sandbox rules and take advantage of relaxed restrictions the next time `nix develop`  is run.

This change prevents file system access to `*.nix` files within the current working directory entirely. I opted for this broad restriction to allow modularisation of policies within multiple nix files but it would be valid to simply prevent access  to `flake.nix` only as an alternative.