### PR TITLE
Allow ability to pull packages for inclusion from project-local nix devshell

### DIFF
--- a/lib/darwin/default.nix
+++ b/lib/darwin/default.nix
@@ -179,6 +179,7 @@
   # harness to point fake domains at a local httpbin. Not part of the
   # public API — leading underscore signals internal-only.
   _proxyRedirects ? { },
+  useDevshell ? false
 }:
 let
   bashWrapper = shared.bashWrapper;
@@ -394,6 +395,21 @@ let
         } > $out
       '';
 
+  conditionalGetDevshellPath = pkgs.lib.optionalString useDevshell ''
+    if nix print-dev-env "$CWD" >/dev/null 2>&1; then
+      DEVSHELL_PATH="$(nix print-dev-env --json "$CWD" 2> /dev/null | ${pkgs.lib.getExe pkgs.jq} -r '.variables.PATH.value')"
+    else
+      DEVSHELL_PATH=
+    fi
+  '';
+
+  conditionalDevshellPatchProfile = pkgs.lib.optionalString useDevshell ''
+    if [ -n "$DEVSHELL_PATH" ]; then
+      DEVSHELL_CLOSURE=$(echo "$DEVSHELL_PATH" | tr ':' '\n' | sed 's/\\bin//g' | xargs -I{} nix path-info --recursive {} | sort | uniq)
+      echo "$DEVSHELL_CLOSURE" | xargs -I{} ${pkgs.lib.getExe' pkgs.coreutils "echo"} -e "    (allow file-read* (subpath \"{}\"))\n    (allow process-exec (subpath \"{}\"))" >> $SANDBOX_PROFILE
+    fi
+  '';
+
 in
 pkgs.writeTextFile {
   name = outName;
@@ -441,12 +457,14 @@ pkgs.writeTextFile {
       ${conditionalNetworkingParams.networkRuntimePatchBashStr}
       ${conditionalNetworkingParams.bashTrapCleanupStr}
 
+      ${conditionalGetDevshellPath}
+      ${conditionalDevshellPatchProfile}
 
       ${conditionalNetworkingParams.sandboxExecBashStr}/usr/bin/env -i \
         HOME="$SANDBOX_HOME" \
         TERM="$TERM" \
         SHELL="${bashWrapper}/bin/bash" \
-        PATH="${pathStr}" \
+        PATH="${pkgs.lib.optionalString useDevshell "$DEVSHELL_PATH:"}${pathStr}" \
         SSL_CERT_DIR="${pkgs.cacert}/etc/ssl/certs" \
         GIT_CONFIG_DIR="$GIT_CONFIG_DIR" \
         TMPDIR=/tmp \

--- a/lib/linux/default.nix
+++ b/lib/linux/default.nix
@@ -85,6 +85,7 @@
   # harness to point fake domains at a local httpbin. Not part of the
   # public API — leading underscore signals internal-only.
   _proxyRedirects ? { },
+  useDevshell ? false
 }:
 let
   bashWrapper = shared.bashWrapper;
@@ -213,6 +214,21 @@ let
       fi
     '';
 
+  conditionalGetDevshellPath = pkgs.lib.optionalString useDevshell ''
+    if nix print-dev-env "$CWD" >/dev/null 2>&1; then
+      DEVSHELL_PATH="$(nix print-dev-env --json "$CWD" 2> /dev/null | ${pkgs.lib.getExe pkgs.jq} -r '.variables.PATH.value')"
+    else
+      DEVSHELL_PATH=
+    fi
+  '';
+  conditionalDevshellExtraClosure = pkgs.lib.optionalString useDevshell ''
+    if [ -n "$DEVSHELL_PATH" ]; then
+      DEVSHELL_CLOSURE=$(echo "$DEVSHELL_PATH" | tr ':' '\n' | sed 's/\\bin//g' | xargs -I{} nix path-info --recursive {} | sort | uniq)
+    else
+      DEVSHELL_CLOSURE=
+    fi
+  '';
+
 in
 pkgs.writeTextFile {
   name = outName;
@@ -228,13 +244,22 @@ pkgs.writeTextFile {
         ${mkFilesStr}
         ${gitDetectionBashStr}
 
+        ${conditionalGetDevshellPath}
+        ${conditionalDevshellExtraClosure}
+
         # Build per-path ro-bind flags for the nix store closure
         CLOSURE_BINDS=""
         BOUND_PREFIXES=()
         while IFS= read -r storePath; do
           CLOSURE_BINDS="$CLOSURE_BINDS --ro-bind $storePath $storePath"
           BOUND_PREFIXES+=("$storePath")
-        done < ${closurePathsFile}
+        done < <(
+          cat ${closurePathsFile}
+          if [ -n "$DEVSHELL_CLOSURE" ]; then
+            printf '%s\n' $DEVSHELL_CLOSURE
+          fi
+        )
+
 
       ${symlinkResolutionBashStr}
       ${sandboxPasswdBashStr}
@@ -275,7 +300,7 @@ pkgs.writeTextFile {
         --setenv HOME "$HOME" \
         --setenv TERM "$TERM" \
         --setenv SHELL "${bashWrapper}/bin/bash" \
-        --setenv PATH "${pathStr}" \
+        --setenv PATH "${pkgs.lib.optionalString useDevshell "$DEVSHELL_PATH:"}${pathStr}" \
         --setenv SSL_CERT_DIR "${pkgs.cacert}/etc/ssl/certs" \
         --setenv TMPDIR /tmp \
         ${conditionalNetworkingParams.sslCertEnvBubblewrapStr} \


### PR DESCRIPTION
Uses flake.devShells.<arch>.default as the reference. I found at times that I wanted to have project local devshells be included in the path (e.g. with cargo or something) but didn't want to make a full pi wrapper for this project, as that is something that should be specific to the individual, I think, rather than the project. Regardless, this adds the useDevshell option that defaults to false to maintain consistency with current revisions. It queries nix for the devshell's path additions and then injects them into the path and the read/execute closure.

I tested on both aarch64-darwin (nix-darwin) and x86_64-linux (NixOS WSL) to ensure that the functionality worked correctly if:
1. useDevshell = false, no devshell present
2. useDevshell = true, no devshell present
3. useDevshell = false, devshell present
4. useDevshell = true, devshell present

There were no regressions in the default codepath.

Unfortunately since it queries nix for the closure at runtime AND evaluates the flake to get the list of packages, it does slow down startup time pretty decently, but again ONLY if useDevshell = true AND there is a devshell present.

I understand that this may not be wanted in which case I will just keep it on my fork just for myself, but I figured it could be useful to others and it doesn't hurt to make the PR, even if it ends up being undesirable.

