### PR TITLE
feat!: rename API args and replace restrictNetwork with allowedDomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,32 @@ The sandbox uses [bubblewrap](https://github.com/containers/bubblewrap) on Linux
 
 Tested with Claude's frontier models — see [Security](#security) for the threat model and known limits.
 
+<details>
+<summary><strong>V0.x -> V1.x Migration guide</strong></summary>
+<br>
+
+A few arguments were renamed, and `restrictNetwork` was removed. If you use an old name you'll get a clear error telling you the new one. Update your config like this:
+
+| Old | New |
+|---|---|
+| `extraEnv = { … }` | `env = { … }` |
+| `stateDirs = [ … ]` | `rwDirs = [ … ]` |
+| `stateFiles = [ … ]` | `rwFiles = [ … ]` |
+| `restrictNetwork = true; allowedDomains = …` | `allowedDomains = …` |
+| `restrictNetwork = true; allowedDomains = [ ]` | `allowedDomains = [ ]` |
+| `restrictNetwork = false` | remove it — just don't set `allowedDomains` |
+
+Network access is now controlled by `allowedDomains` on its own: leave it unset for open internet, list the domains you want to allow, or use `[ ]` to block everything.
+
+</details>
+
 ## What the sandbox allows
 
 - **Project directory** — read/write access to the directory you launch the agent from.
-- **Declared state** — read/write access to anything you list in `stateDirs` or `stateFiles`.
+- **Declared state** — read/write access to anything you list in `rwDirs` or `rwFiles`.
 - **Allowed packages** — the binaries you list in `allowedPackages` are on the agent's PATH (plus `bash` and `cacert`).
-- **Network** — unrestricted by default. Set `restrictNetwork = true` to limit access to the domains and methods in `allowedDomains`.
-- **Environment** — only variables you pass via `extraEnv` reach the agent; the host environment is otherwise cleared.
+- **Network** — unrestricted by default. Set `allowedDomains` to limit the agent to specific domains (and, optionally, specific HTTP methods).
+- **Environment** — only variables you pass via `env` reach the agent; the host environment is otherwise cleared.
 - **Git** — the repo's `.git` directory is exposed, including when it sits outside the project tree (worktrees).
 
 Everything else is denied. `$HOME` is an ephemeral writable tmpfs that disappears when the sandbox exits.
@@ -63,11 +82,10 @@ If you want to keep the original command name as the alias, change the `outName`
 | `binName` | yes | Name of the binary inside `pkg/bin/` |
 | `outName` | yes | Name for the resulting wrapped binary and the command to invoke it with |
 | `allowedPackages` | yes | Packages whose `bin/` dirs form the sandbox PATH. `bash` and `cacert` are provided by default — the sandbox needs a shell to run, and `cacert` is required for HTTPS to work. |
-| `stateDirs` | no | Directories the agent can read/write (e.g. `~/.config/claude`) |
-| `stateFiles` | no | Individual files the agent can read/write |
-| `extraEnv` | no | Additional environment variables as an attrset |
-| `restrictNetwork` | no | When `true`, network is limited to `allowedDomains` (default `false`) |
-| `allowedDomains` | no | Domains the sandbox can reach when `restrictNetwork = true`. Attrset mapping domains to `"*"` or a list of HTTP methods, or a list of domain strings (all methods allowed). |
+| `rwDirs` | no | Directories the agent can read/write (e.g. `~/.config/claude`) |
+| `rwFiles` | no | Individual files the agent can read/write |
+| `env` | no | Additional environment variables as an attrset |
+| `allowedDomains` | no | Limits which domains the sandbox can reach. Leave unset for open internet. Accepts a list of domains (all methods allowed), or an attrset mapping each domain to `"*"` or a list of HTTP methods. `[ ]` blocks all internet access. |
 
 A minimal example — the arguments are the same whether you use a flake or a `shell.nix`:
 
@@ -77,13 +95,12 @@ mkSandbox {
   binName = "claude";
   outName = "claude-sandboxed";
   allowedPackages = [ pkgs.coreutils pkgs.git pkgs.ripgrep ];
-  stateDirs = [ "$HOME/.claude" ];
-  stateFiles = [ ];
-  extraEnv = {
+  rwDirs = [ "$HOME/.claude" ];
+  rwFiles = [ ];
+  env = {
     CLAUDE_CODE_OAUTH_TOKEN = "$CLAUDE_CODE_OAUTH_TOKEN";
     CLAUDE_CONFIG_DIR = "$HOME/.claude";
   };
-  restrictNetwork = true;
   allowedDomains = {
     "anthropic.com" = "*";
     "claude.com" = "*";
@@ -94,10 +111,10 @@ mkSandbox {
 ```
 
 <details>
-<summary><strong>Why set <code>CLAUDE_CONFIG_DIR</code> and not add <code>~/.claude.json</code> as a <code>stateFile</code>?</strong></summary>
+<summary><strong>Why set <code>CLAUDE_CONFIG_DIR</code> and not add <code>~/.claude.json</code> as a <code>rwFile</code>?</strong></summary>
 <br>
 
-`CLAUDE_CONFIG_DIR` is set to `$HOME/.claude` so that `~/.claude.json` is written inside the read/write `stateDir`. If you instead add `~/.claude.json` as a `stateFile`, when Claude updates configuration it writes temporary files to the ephemeral home root. It then tries to rename these to `~/.claude.json`, which can fail or behave unexpectedly because the temporary files land outside any declared `stateDir` or `stateFile`. This can occasionally corrupt the `~/.claude.json` file.
+`CLAUDE_CONFIG_DIR` is set to `$HOME/.claude` so that `~/.claude.json` is written inside the read/write `rwDir`. If you instead add `~/.claude.json` as a `rwFile`, when Claude updates configuration it writes temporary files to the ephemeral home root. It then tries to rename these to `~/.claude.json`, which can fail or behave unexpectedly because the temporary files land outside any declared `rwDir` or `rwFile`. This can occasionally corrupt the `~/.claude.json` file.
 <br>
 <br>
 
@@ -107,7 +124,7 @@ mkSandbox {
 
 ### Network restrictions
 
-By default, network access is unrestricted. But you can optionally restrict connections to specific domains by setting `restrictNetwork = true` and providing `allowedDomains`.
+By default, network access is unrestricted. To restrict it, set `allowedDomains` — the sandbox can then only reach the domains you list. Leave it unset for open internet, or set it to `[ ]` to block all network access.
 
 `allowedDomains` accepts two formats:
 
@@ -116,7 +133,7 @@ By default, network access is unrestricted. But you can optionally restrict conn
 
 Domains are suffix-matched, so `"anthropic.com"` will capture all `*.anthropic.com` subdomains.
 
-When `restrictNetwork = true`, all HTTP/HTTPS traffic is routed through a filtering proxy that inspects requests by domain and HTTP method. The sandbox cannot bypass the proxy and DNS resolution is blocked. WebSocket connections are not permitted.
+When `allowedDomains` is set, all HTTP/HTTPS traffic is routed through a filtering proxy that inspects requests by domain and HTTP method. The sandbox cannot bypass the proxy and DNS resolution is blocked. WebSocket connections are not permitted.
 
 Blocked requests are logged to `/tmp/sandbox-proxy.log`. See [Git](#git) for limitations on SSH-based remotes.
 
@@ -136,10 +153,10 @@ export CLAUDE_CODE_OAUTH_TOKEN="<your_token_here>"
 export GITHUB_TOKEN="<your_token_here>"
 ```
 
-Pass the variable reference (not the value) into `extraEnv`:
+Pass the variable reference (not the value) into `env`:
 
 ```nix
-extraEnv = {
+env = {
   CLAUDE_CODE_OAUTH_TOKEN = "$CLAUDE_CODE_OAUTH_TOKEN";
   ...
 };
@@ -148,15 +165,15 @@ extraEnv = {
 Alternatively, if you store your secret in a file (for example if you use sops), you can set a command that will read the secret at runtime:
 
 ```nix
-extraEnv = {
+env = {
   CLAUDE_CODE_OAUTH_TOKEN = "$(${pkgs.coreutils}/bin/cat /run/secrets/claude-code-oauth-token)";
   ...
 };
 ```
 
-### Credential files via `stateDirs`
+### Credential files via `rwDirs`
 
-If your agent stores credentials in files (e.g. Claude Code uses `~/.claude/`), you can run the login flow unsandboxed first, then expose the credential directory via `stateDirs`. The sandboxed agent will pick up the cached credentials.
+If your agent stores credentials in files (e.g. Claude Code uses `~/.claude/`), you can run the login flow unsandboxed first, then expose the credential directory via `rwDirs`. The sandboxed agent will pick up the cached credentials.
 
 <details>
 <summary><strong>On macOS you will need to export the credentials from the Keychain first</strong></summary>
@@ -194,7 +211,7 @@ if most_recent: print(most_recent[0])
 
 This finds all Claude Code credential entries in the Keychain and exports the one with the most recent expiry.
 
-Then expose `~/.claude` via `stateDirs`. The sandboxed agent will read credentials from `~/.claude/.credentials.json` when Keychain access is unavailable.
+Then expose `~/.claude` via `rwDirs`. The sandboxed agent will read credentials from `~/.claude/.credentials.json` when Keychain access is unavailable.
 
 Note: OAuth access tokens expire. You will need to re-run the export command periodically to refresh the credentials file.
 
@@ -210,16 +227,16 @@ The sandbox allows access to the local git directory, including from within work
 
 ### Remote access (push / pull / fetch)
 
-Interacting with remotes requires authentication. The recommended approach is to use HTTPS rather than SSH based remotes. The simplest way to authenticate is by passing a token via `extraEnv` (e.g. `GITHUB_TOKEN`), but you can also configure a [git credential helper](https://git-scm.com/doc/credential-helpers) to store your token for reuse so you don't have to pass it via environment variable.
+Interacting with remotes requires authentication. The recommended approach is to use HTTPS rather than SSH based remotes. The simplest way to authenticate is by passing a token via `env` (e.g. `GITHUB_TOKEN`), but you can also configure a [git credential helper](https://git-scm.com/doc/credential-helpers) to store your token for reuse so you don't have to pass it via environment variable.
 
-SSH based remotes (e.g. `git@github.com:...`) won't work by default — SSH keys are not accessible because `$HOME` is masked, and when `restrictNetwork = true` the proxy only handles HTTP/HTTPS so SSH traffic is blocked entirely. You can expose your SSH directory via `stateDirs` (e.g. `$HOME/.ssh`) and set `restrictNetwork = false` to enable SSH based git remotes, but this is not recommended.
+SSH based remotes (e.g. `git@github.com:...`) won't work by default — SSH keys are not accessible because `$HOME` is masked, and when `allowedDomains` is set the proxy only handles HTTP/HTTPS so SSH traffic is blocked entirely. You can expose your SSH directory via `rwDirs` (e.g. `$HOME/.ssh`) and leave `allowedDomains` unset (open network) to enable SSH based git remotes, but this is not recommended.
 
 ### Git identity
 
-To give the agent its own git identity, pass the following environment variables via `extraEnv`:
+To give the agent its own git identity, pass the following environment variables via `env`:
 
 ```nix
-    extraEnv = {
+    env = {
       ...
       GIT_AUTHOR_NAME = "claude";
       GIT_AUTHOR_EMAIL = "claude@localhost";
@@ -228,26 +245,26 @@ To give the agent its own git identity, pass the following environment variables
     };
 ```
 
-> **Note:** `.git/config` is read-only inside the sandbox, so `git config` commands run by the agent will not persist. Use `extraEnv` (as above) or configure git on the host before entering the sandbox.
+> **Note:** `.git/config` is read-only inside the sandbox, so `git config` commands run by the agent will not persist. Use `env` (as above) or configure git on the host before entering the sandbox.
 
 ## Common Patterns / Recipes
 
 ### Python with uv
 
-uv needs access to its cache dirs via `stateDirs`, otherwise it will re-download dependencies on every invocation. On NixOS, pre-compiled wheels will also fail to find glibc unless you thread `LD_LIBRARY_PATH` through from the host and use a nix-managed Python instead of a uv-managed one. See [`shells/claude-uv.shell.nix`](shells/claude-uv.shell.nix) for the full setup.
+uv needs access to its cache dirs via `rwDirs`, otherwise it will re-download dependencies on every invocation. On NixOS, pre-compiled wheels will also fail to find glibc unless you thread `LD_LIBRARY_PATH` through from the host and use a nix-managed Python instead of a uv-managed one. See [`shells/claude-uv.shell.nix`](shells/claude-uv.shell.nix) for the full setup.
 
 ### Node.js with npm
 
-For Node, you can simply add the npm cache as a `stateDir`.
+For Node, you can simply add the npm cache as a `rwDir`.
 
 ```nix
 allowedPackages = [ pkgs.nodejs pkgs.npm ];
-stateDirs = [ "$HOME/.npm" ]; # Allow npm cache
+rwDirs = [ "$HOME/.npm" ]; # Allow npm cache
 ```
 
 ## Debugging
 
-If the agent fails to perform a tool call, or file read/write, the sandbox is likely blocking a path that needs to be added to `stateDirs` or `stateFiles`.
+If the agent fails to perform a tool call, or file read/write, the sandbox is likely blocking a path that needs to be added to `rwDirs` or `rwFiles`.
 
 The easiest way to explore the sandbox environment is to wrap `bash` itself with the same config as your agent and poke around interactively.
 
@@ -258,9 +275,8 @@ bash-sandboxed = sandbox.mkSandbox {
   binName = "bash";
   outName = "bash-sandboxed";
   allowedPackages = [ pkgs.coreutils ];
-  stateDirs = [ "$HOME/.claude" ];
-  stateFiles = [];
-  restrictNetwork = true;
+  rwDirs = [ "$HOME/.claude" ];
+  rwFiles = [];
   allowedDomains = { "httpbin.org" = "*"; };
 };
 ```
@@ -269,20 +285,20 @@ Running `bash-sandboxed` drops you into a shell with exactly the same filesystem
 
 ```bash
 touch /tmp/test && rm /tmp/test   # /tmp should be writable
-curl https://example.com          # depends on restrictNetwork setting
+curl https://example.com          # depends on your allowedDomains setting
 which git                         # allowedPackages should be on PATH
 ls /some/other/path               # should fail — confirming sandbox is active
 cat ~/.ssh/id_ed25519             # should fail - shouldn't be able to read unspecified files in $HOME
-ls $HOME                          # empty dir with symlinks to stateDirs
+ls $HOME                          # empty dir with symlinks to rwDirs
 touch $HOME/.test && rm $HOME/.test  # writes allowed (but ephemeral)
-ls $HOME/.claude                  # should work if in stateDirs (symlinked)
+ls $HOME/.claude                  # should work if in rwDirs (symlinked)
 curl https://httpbin.org/get      # allowed domain — should work
 curl https://example.com          # blocked domain — should fail
 ```
 
-See [`debug/bash.shell.nix`](debug/bash.shell.nix) for a ready-to-use template (has `restrictNetwork = true` with `httpbin.org` allowed for testing).
+See [`debug/bash.shell.nix`](debug/bash.shell.nix) for a ready-to-use template (has `allowedDomains` set to `httpbin.org` for testing).
 
-**Network issues:** If `restrictNetwork = true` and requests are failing, check which domains are being blocked:
+**Network issues:** If you've set `allowedDomains` and requests are failing, check which domains are being blocked:
 
 ```bash
 tail -f /tmp/sandbox-proxy.log
@@ -307,8 +323,8 @@ This section explains what the sandbox is and isn't designed to protect against,
 If the agent does something it shouldn't — runs a bad prompt, processes a malicious file, picks up a compromised dependency, or hallucinates a destructive command — the sandbox stops the damage from spreading outside the project directory. Concretely:
 
 - It can't read your SSH keys, browser sessions, password manager, other projects' source code, or anything else in your home directory outside the paths you explicitly expose.
-- It can't delete or modify files outside the project directory and your declared `stateDirs` / `stateFiles`.
-- It can't reach the internet outside the domains you allow (when `restrictNetwork = true`).
+- It can't delete or modify files outside the project directory and your declared `rwDirs` / `rwFiles`.
+- It can't reach the internet outside the domains you allow (when `allowedDomains` is set).
 - It can't talk to local services on your laptop — databases, dev servers, the SSH agent, other terminal windows, etc.
 - It can only run the tools you list in `allowedPackages`.
 - It can't see your other running programs, read environment variables they have set, or interfere with other terminals you have open.
@@ -318,7 +334,7 @@ If the agent does something it shouldn't — runs a bad prompt, processes a mali
 The sandbox is an **isolation** boundary, not an **anonymity** boundary, and not a defense against an attacker who has already taken over your machine in some other way.
 
 - The agent can fingerprint your machine. It can see your hostname, hardware model, CPU, RAM, OS version, and rough network details. If you need the agent to *not know which machine it's running on*, this isn't the tool — you want a VM or a separate device.
-- Anything you hand the agent, it has. If you expose your `~/.claude` directory (or any credential file) via `stateDirs`, or pass a token through `extraEnv`, the agent can read it — that's how it logs in. A compromised agent has the same access to those credentials as your shell does. Treat this the way you'd treat handing the token to any other CLI tool you didn't write yourself.
+- Anything you hand the agent, it has. If you expose your `~/.claude` directory (or any credential file) via `rwDirs`, or pass a token through `env`, the agent can read it — that's how it logs in. A compromised agent has the same access to those credentials as your shell does. Treat this the way you'd treat handing the token to any other CLI tool you didn't write yourself.
 - The agent can edit its own sandbox config. `flake.nix` lives inside the project directory and is writable from inside the sandbox. An agent could weaken its own restrictions for the *next* session. Changes don't take effect until you re-enter the dev shell, so it's worth reviewing `git diff` before you do.
 - No defense against root or kernel bugs. If something on your machine has already gained administrator-level access, or there's a deeper bug in the operating system itself, this sandbox can't stop it.
 
@@ -341,7 +357,7 @@ If your threat model is *"I assume the agent is actively malicious and need it t
 ## Caveats
 
 - `sandbox-exec` is deprecated on macOS. It remains the only native unprivileged sandboxing mechanism and currently works on macOS 26 (Tahoe) and older, but may break in a future release.
-- Symlinks inside `stateDirs` and `stateFiles` are only followed to already-permitted paths. A symlink is usable only if its target is the Nix store, the working directory, the Git directory, or another declared `stateDir`/`stateFile`. Anything else is blocked — this prevents an agent from planting a symlink during a session to expand its own sandbox on the next startup (e.g. `~/.claude/evil -> /etc/shadow`). To expose a non-permitted path that's currently reached via a symlink, declare it explicitly as a `stateDir` or `stateFile`. Symlinks into the Nix store are read-only. Platform differences: on Linux, only top-level symlinks inside a `stateDir` are detected (the startup scan is one level deep) and blocked targets produce a `sandbox: WARNING` line on startup; on macOS, symlinks are followed at any depth and denials happen at runtime — check `log show --predicate 'eventMessage CONTAINS "deny"'`.
+- Symlinks inside `rwDirs` and `rwFiles` are only followed to already-permitted paths. A symlink is usable only if its target is the Nix store, the working directory, the Git directory, or another declared `rwDir`/`rwFile`. Anything else is blocked — this prevents an agent from planting a symlink during a session to expand its own sandbox on the next startup (e.g. `~/.claude/evil -> /etc/shadow`). To expose a non-permitted path that's currently reached via a symlink, declare it explicitly as a `rwDir` or `rwFile`. Symlinks into the Nix store are read-only. Platform differences: on Linux, only top-level symlinks inside a `rwDir` are detected (the startup scan is one level deep) and blocked targets produce a `sandbox: WARNING` line on startup; on macOS, symlinks are followed at any depth and denials happen at runtime — check `log show --predicate 'eventMessage CONTAINS "deny"'`.
 - Tested on x86_64-linux and aarch64-darwin. Other architectures should work but are untested.
 
 ## Similar projects

--- a/debug/bash.shell.nix
+++ b/debug/bash.shell.nix
@@ -1,13 +1,13 @@
 # Debugging shell: drops you into a bash session inside the sandbox.
-# Mirror the stateDirs, stateFiles, and allowedPackages from your agent config
+# Mirror the rwDirs, rwFiles, and allowedPackages from your agent config
 # to reproduce the exact environment your agent will see.
 #
 # Usage:
 #   nix-shell debug/bash.shell.nix
 #
 # Once inside, try:
-#   ls $HOME                   # empty ephemeral tmpfs with symlinks to stateDirs/stateFiles
-#   cat $HOME/.claude.json     # should work if in stateFiles
+#   ls $HOME                   # empty ephemeral tmpfs with symlinks to rwDirs/rwFiles
+#   cat $HOME/.claude.json     # should work if in rwFiles
 #   ls /tmp                    # should be writable scratch space
 #   curl https://httpbin.org/get       # allowed domain (GET only) — should work
 #   curl -X POST https://httpbin.org/post  # blocked method — should fail
@@ -24,10 +24,9 @@ let
     outName = "bash-sandboxed";
     allowedPackages = [ pkgs.coreutils pkgs.curl pkgs.git pkgs.which ];
     # Mirror these from your agent config:
-    stateDirs = [ "$HOME/.claude" ];
-    stateFiles = [ "$HOME/.claude.json" ];
-    extraEnv = { HELLO = "world"; };
-    restrictNetwork = true;
+    rwDirs = [ "$HOME/.claude" ];
+    rwFiles = [ "$HOME/.claude.json" ];
+    env = { HELLO = "world"; };
     allowedDomains = { "httpbin.org" = [ "GET" ]; };
   };
 in pkgs.mkShell {

--- a/lib/darwin/default.nix
+++ b/lib/darwin/default.nix
@@ -96,7 +96,7 @@
       that live under the real HOME are symlinked into the sandbox
       HOME so that $HOME-relative lookups resolve through to the
       real (Seatbelt-allowed) targets. The temp directory is cleaned
-      up on exit via a trap. stateDirs and stateFiles are resolved
+      up on exit via a trap. rwDirs and rwFiles are resolved
       to absolute paths before HOME is reassigned.
 
     Timezone:
@@ -120,7 +120,7 @@
       $GIT_CONFIG_DIR       — ~/.config/git (read-only) for user
                               gitconfig, gitignore, etc.
 
-    stateDirs / stateFiles:
+    rwDirs / rwFiles:
       Each gets a (allow file-read* file-write* ...) rule. Dirs use
       (subpath ...) so all contents are accessible. Files use
       (literal ...) for exact-path access only.
@@ -169,16 +169,22 @@
   binName,
   outName,
   allowedPackages,
-  stateDirs ? [ ],
-  stateFiles ? [ ],
-  extraEnv ? { },
-  restrictNetwork ? false,
-  allowedDomains ? [ ],
+  rwDirs ? [ ],
+  rwFiles ? [ ],
+  env ? { },
+  allowedDomains ? null,
   # Internal: maps "host" → "addr:port" so the proxy dials the local address
   # for those hosts instead of resolving the original. Used by the test
   # harness to point fake domains at a local httpbin. Not part of the
   # public API — leading underscore signals internal-only.
   _proxyRedirects ? { },
+  # Legacy args that should not be used in new code. Still accepted for
+  # backward compatibility, but will throw an error if used with
+  # assertNoLegacyArgs.
+  restrictNetwork ? null,
+  stateDirs ? null,
+  stateFiles ? null,
+  extraEnv ? null,
 }:
 let
   bashWrapper = shared.bashWrapper;
@@ -191,13 +197,13 @@ let
   # Generate indexed param names
   stateDirParams = builtins.genList (i: {
     name = "STATE_DIR_${toString i}";
-    path = builtins.elemAt stateDirs i;
-  }) (builtins.length stateDirs);
+    path = builtins.elemAt rwDirs i;
+  }) (builtins.length rwDirs);
 
   stateFileParams = builtins.genList (i: {
     name = "STATE_FILE_${toString i}";
-    path = builtins.elemAt stateFiles i;
-  }) (builtins.length stateFiles);
+    path = builtins.elemAt rwFiles i;
+  }) (builtins.length rwFiles);
 
   # For the .sb file
   seatbeltAllowReadWriteExec = builtins.concatStringsSep "\n" (
@@ -206,8 +212,7 @@ let
       # scheme
       ''
         (allow file-read* file-write* (subpath (param "${p.name}")))
-        (allow process-exec (subpath (param "${p.name}")))''
-    ) stateDirParams
+        (allow process-exec (subpath (param "${p.name}")))'') stateDirParams
   );
 
   seatbeltAllowFiles = builtins.concatStringsSep "\n" (
@@ -223,7 +228,7 @@ let
     map (p: ''-D ${p.name}="$_RESOLVED_${p.name}"'') stateFileParams
   );
 
-  # Resolve stateDirs/stateFiles while HOME is still real
+  # Resolve rwDirs/rwFiles while HOME is still real
   resolveStateDirsStr = builtins.concatStringsSep "\n" (
     map (p: ''_RESOLVED_${p.name}="${p.path}"'') stateDirParams
   );
@@ -246,25 +251,24 @@ let
             _REL="''${_RESOLVED_${p.name}#$REAL_HOME/}"
             mkdir -p "$SANDBOX_HOME/$(dirname "$_REL")"
             ln -sfn "$_RESOLVED_${p.name}" "$SANDBOX_HOME/$_REL"
-          fi''
-      ) params
+          fi'') params
     );
 
   symlinkStateDirsStr = mkSymlinkHomeMappingStr stateDirParams;
   symlinkStateFilesStr = mkSymlinkHomeMappingStr stateFileParams;
 
-  mkDirsStr = builtins.concatStringsSep "\n" (map (dir: ''mkdir -p "${dir}"'') stateDirs);
-  mkFilesStr = builtins.concatStringsSep "\n" (map (file: ''touch "${file}"'') stateFiles);
+  mkDirsStr = builtins.concatStringsSep "\n" (map (dir: ''mkdir -p "${dir}"'') rwDirs);
+  mkFilesStr = builtins.concatStringsSep "\n" (map (file: ''touch "${file}"'') rwFiles);
 
   extraEnvInlineStr = builtins.concatStringsSep " \\\n        " (
-    map (name: "${name}=${builtins.toJSON extraEnv.${name}}") (builtins.attrNames extraEnv)
+    map (name: "${name}=${builtins.toJSON env.${name}}") (builtins.attrNames env)
   );
 
   conditionalNetworkingParams = import ./networking.nix {
     pkgs = pkgs;
     shared = shared;
-    restrictNetwork = restrictNetwork;
-    allowedDomains = allowedDomains;
+    restrictNetwork = allowedDomains != null;
+    allowedDomains = if allowedDomains != null then allowedDomains else [ ];
     _proxyRedirects = _proxyRedirects;
   };
 
@@ -334,7 +338,7 @@ let
     '';
 
   # Collect ancestors for repo root (or CWD) → REAL_HOME, plus
-  # each stateDir/stateFile → REAL_HOME so symlink targets are reachable.
+  # each rwDir/rwFile → REAL_HOME so symlink targets are reachable.
   ancestorTraversalBashStr =
     let
       stateDirTraversals = builtins.concatStringsSep "\n" (
@@ -395,82 +399,90 @@ let
       '';
 
 in
-pkgs.writeTextFile {
-  name = outName;
-  executable = true;
-  destination = "/bin/${outName}";
-  text =
-    # bash
-    ''
-      #!${pkgs.bashInteractive}/bin/bash
-      CWD=$(pwd)
-      ${conditionalNetworkingParams.warnIgnoredDomainsBashStr}
+builtins.seq
+  (shared.assertNoLegacyArgs {
+    restrictNetwork = restrictNetwork;
+    extraEnv = extraEnv;
+    stateDirs = stateDirs;
+    stateFiles = stateFiles;
+  })
+  (
+    pkgs.writeTextFile {
+      name = outName;
+      executable = true;
+      destination = "/bin/${outName}";
+      text =
+        # bash
+        ''
+          #!${pkgs.bashInteractive}/bin/bash
+          CWD=$(pwd)
 
-      # Ensure stateDirs/stateFiles exist while HOME still points at real home
-      ${mkDirsStr}
-      ${mkFilesStr}
+          # Ensure rwDirs/rwFiles exist while HOME still points at real home
+          ${mkDirsStr}
+          ${mkFilesStr}
 
-      ${gitDetectionBashStr}
-      ${ttyDetectionBashStr}
+          ${gitDetectionBashStr}
+          ${ttyDetectionBashStr}
 
-      # Capture real HOME paths before redirecting
-      GIT_CONFIG_DIR="$HOME/.config/git"
+          # Capture real HOME paths before redirecting
+          GIT_CONFIG_DIR="$HOME/.config/git"
 
-      # Resolve stateDirs/stateFiles paths while $HOME still points at real home
-      ${resolveStateDirsStr}
-      ${resolveStateFilesStr}
+          # Resolve rwDirs/rwFiles paths while $HOME still points at real home
+          ${resolveStateDirsStr}
+          ${resolveStateFilesStr}
 
-      # Create an ephemeral HOME so subprocesses don't touch the real home.
-      # Lives under /tmp which is already allowed read-write in the profile.
-      REAL_HOME="$HOME"
-      SANDBOX_HOME=$(mktemp -d /private/tmp/sandbox-home.XXXXXX)
-      _SANDBOX_PASSWD=$(mktemp /tmp/sandbox-passwd.XXXXXX)
-      printf 'user:x:%s:%s:sandbox user:%s:/bin/sh\n' "$(id -u)" "$(id -g)" "$REAL_HOME" > "$_SANDBOX_PASSWD"
+          # Create an ephemeral HOME so subprocesses don't touch the real home.
+          # Lives under /tmp which is already allowed read-write in the profile.
+          REAL_HOME="$HOME"
+          SANDBOX_HOME=$(mktemp -d /private/tmp/sandbox-home.XXXXXX)
+          _SANDBOX_PASSWD=$(mktemp /tmp/sandbox-passwd.XXXXXX)
+          printf 'user:x:%s:%s:sandbox user:%s:/bin/sh\n' "$(id -u)" "$(id -g)" "$REAL_HOME" > "$_SANDBOX_PASSWD"
 
-      # Symlink state dirs/files into sandbox HOME so $HOME-relative lookups
-      # reach the real paths through the Seatbelt-allowed targets.
-      ${symlinkStateDirsStr}
-      ${symlinkStateFilesStr}
+          # Symlink state dirs/files into sandbox HOME so $HOME-relative lookups
+          # reach the real paths through the Seatbelt-allowed targets.
+          ${symlinkStateDirsStr}
+          ${symlinkStateFilesStr}
 
-      # Walk ancestor directories between REAL_HOME and REPO_ROOT (or CWD)
-      # and patch the seatbelt profile at runtime with file-read-metadata rules.
-      ${ancestorTraversalBashStr}
-      ${ancestorProfilePatchBashStr}
+          # Walk ancestor directories between REAL_HOME and REPO_ROOT (or CWD)
+          # and patch the seatbelt profile at runtime with file-read-metadata rules.
+          ${ancestorTraversalBashStr}
+          ${ancestorProfilePatchBashStr}
 
-      ${conditionalNetworkingParams.proxyStartupBashStr}
-      ${conditionalNetworkingParams.networkRuntimePatchBashStr}
-      ${conditionalNetworkingParams.bashTrapCleanupStr}
+          ${conditionalNetworkingParams.proxyStartupBashStr}
+          ${conditionalNetworkingParams.networkRuntimePatchBashStr}
+          ${conditionalNetworkingParams.bashTrapCleanupStr}
 
 
-      ${conditionalNetworkingParams.sandboxExecBashStr}/usr/bin/env -i \
-        HOME="$SANDBOX_HOME" \
-        TERM="$TERM" \
-        SHELL="${bashWrapper}/bin/bash" \
-        PATH="${pathStr}" \
-        SSL_CERT_DIR="${pkgs.cacert}/etc/ssl/certs" \
-        GIT_CONFIG_DIR="$GIT_CONFIG_DIR" \
-        TMPDIR=/tmp \
-        ${conditionalNetworkingParams.caCertEnvInlineBashStr} \
-        ${conditionalNetworkingParams.proxyEnvInlineBashStr} \
-        ${extraEnvInlineStr} \
-        /usr/bin/sandbox-exec \
-        -f "$SANDBOX_PROFILE" \
-        -D CWD="$CWD" \
-        -D GIT_DIR="$GIT_DIR_PARAM" \
-        -D GIT_HOOKS_DIR="$GIT_HOOKS_DIR_PARAM" \
-        -D GIT_CONFIG_FILE="$GIT_CONFIG_FILE_PARAM" \
-        -D REPO_ROOT="$REPO_ROOT" \
-        -D REPO_ROOT_PARENT="$REPO_ROOT_PARENT" \
-        -D MY_TTY="$MY_TTY" \
-        -D GIT_CONFIG_DIR="$GIT_CONFIG_DIR" \
-        -D TMPDIR="/tmp" \
-        -D HOME="$SANDBOX_HOME"  \
-        -D REAL_HOME="$REAL_HOME" \
-        -D SANDBOX_PASSWD="$_SANDBOX_PASSWD" \
-        -D HOME_CACHE="$SANDBOX_HOME/.cache" \
-        -D HOME_LOCAL="$SANDBOX_HOME/.local" \
-        -D HOME_LOCAL_STATE="$SANDBOX_HOME/.local/state" \
-        -D HOME_LOCAL_SHARE="$SANDBOX_HOME/.local/share" ${stateDirFlags} ${stateFileFlags} \
-        ${pkg}/bin/${binName} "$@"
-    '';
-}
+          ${conditionalNetworkingParams.sandboxExecBashStr}/usr/bin/env -i \
+            HOME="$SANDBOX_HOME" \
+            TERM="$TERM" \
+            SHELL="${bashWrapper}/bin/bash" \
+            PATH="${pathStr}" \
+            SSL_CERT_DIR="${pkgs.cacert}/etc/ssl/certs" \
+            GIT_CONFIG_DIR="$GIT_CONFIG_DIR" \
+            TMPDIR=/tmp \
+            ${conditionalNetworkingParams.caCertEnvInlineBashStr} \
+            ${conditionalNetworkingParams.proxyEnvInlineBashStr} \
+            ${extraEnvInlineStr} \
+            /usr/bin/sandbox-exec \
+            -f "$SANDBOX_PROFILE" \
+            -D CWD="$CWD" \
+            -D GIT_DIR="$GIT_DIR_PARAM" \
+            -D GIT_HOOKS_DIR="$GIT_HOOKS_DIR_PARAM" \
+            -D GIT_CONFIG_FILE="$GIT_CONFIG_FILE_PARAM" \
+            -D REPO_ROOT="$REPO_ROOT" \
+            -D REPO_ROOT_PARENT="$REPO_ROOT_PARENT" \
+            -D MY_TTY="$MY_TTY" \
+            -D GIT_CONFIG_DIR="$GIT_CONFIG_DIR" \
+            -D TMPDIR="/tmp" \
+            -D HOME="$SANDBOX_HOME"  \
+            -D REAL_HOME="$REAL_HOME" \
+            -D SANDBOX_PASSWD="$_SANDBOX_PASSWD" \
+            -D HOME_CACHE="$SANDBOX_HOME/.cache" \
+            -D HOME_LOCAL="$SANDBOX_HOME/.local" \
+            -D HOME_LOCAL_STATE="$SANDBOX_HOME/.local/state" \
+            -D HOME_LOCAL_SHARE="$SANDBOX_HOME/.local/share" ${stateDirFlags} ${stateFileFlags} \
+            ${pkg}/bin/${binName} "$@"
+        '';
+    }
+  )

--- a/lib/darwin/networking.nix
+++ b/lib/darwin/networking.nix
@@ -7,7 +7,6 @@
 }:
 let
   mkAllowlistFile = shared.mkAllowlistFile;
-  hasAllowedDomains = shared.hasAllowedDomains;
   mkProxyStartupBashStr = shared.mkProxyStartupBashStr;
 in
 if restrictNetwork then
@@ -15,7 +14,6 @@ if restrictNetwork then
     allowlistFileStr = mkAllowlistFile allowedDomains;
   in
   {
-    warnIgnoredDomainsBashStr = "";
     proxyEnvInlineBashStr =
       # bash
       ''HTTP_PROXY="http://127.0.0.1:$_PROXY_PORT" HTTPS_PROXY="http://127.0.0.1:$_PROXY_PORT" http_proxy="http://127.0.0.1:$_PROXY_PORT" https_proxy="http://127.0.0.1:$_PROXY_PORT"'';
@@ -56,14 +54,6 @@ if restrictNetwork then
   }
 else
   {
-    warnIgnoredDomainsBashStr =
-      if (hasAllowedDomains allowedDomains) then
-        # bash
-        ''
-          echo "${shared.warnPrefix} allowedDomains is set but restrictNetwork is false — domains will be ignored" >&2
-        ''
-      else
-        "";
     proxyEnvInlineBashStr = "";
     caCertEnvInlineBashStr =
       # bash

--- a/lib/linux/default.nix
+++ b/lib/linux/default.nix
@@ -28,8 +28,8 @@
                       mounted rw on top of this.
       Read-write bind mounts:
         $CWD        — the project directory (always)
-        stateDirs   — each path gets a --bind (e.g., ~/.config/claude)
-        stateFiles  — each path gets a --bind (e.g., specific rc files)
+        rwDirs      — each path gets a --bind (e.g., ~/.config/claude)
+        rwFiles     — each path gets a --bind (e.g., specific rc files)
         $GIT_DIR    — the .git dir, auto-detected. Needed when CWD is a
                       worktree and .git/common is outside CWD.
       Symlinks:
@@ -52,7 +52,7 @@
       "No such file or directory":
         The binary is trying to access a path that isn't mounted.
         Run the wrapper with `strace -f -e trace=openat` to find the
-        path, then add it to stateDirs/stateFiles.
+        path, then add it to rwDirs/rwFiles.
 
       "Operation not permitted" on /proc or /dev:
         Unprivileged user namespaces may be disabled on the host.
@@ -75,16 +75,22 @@
   binName,
   outName,
   allowedPackages,
-  stateDirs ? [ ],
-  stateFiles ? [ ],
-  extraEnv ? { },
-  restrictNetwork ? false,
-  allowedDomains ? [ ],
+  rwDirs ? [ ],
+  rwFiles ? [ ],
+  env ? { },
+  allowedDomains ? null,
   # Internal: maps "host" → "addr:port" so the proxy dials the local address
   # for those hosts instead of resolving the original. Used by the test
   # harness to point fake domains at a local httpbin. Not part of the
   # public API — leading underscore signals internal-only.
   _proxyRedirects ? { },
+  # Legacy args that should not be used in new code. Still accepted for
+  # backward compatibility, but will throw an error if used with
+  # assertNoLegacyArgs.
+  restrictNetwork ? null,
+  extraEnv ? null,
+  stateDirs ? null,
+  stateFiles ? null,
 }:
 let
   bashWrapper = shared.bashWrapper;
@@ -98,12 +104,12 @@ let
     ::1       localhost
   '';
   pathStr = pkgs.lib.makeBinPath (allowedPackages ++ implicitPackages);
-  mkDirsStr = builtins.concatStringsSep "\n" (map (dir: ''mkdir -p "${dir}"'') stateDirs);
-  mkFilesStr = builtins.concatStringsSep "\n" (map (file: ''touch "${file}"'') stateFiles);
-  bindDirsStr = builtins.concatStringsSep " " (map (dir: ''--bind "${dir}" "${dir}"'') stateDirs);
-  # Adds each stateDir to the BOUND_PREFIXES shell array at runtime
+  mkDirsStr = builtins.concatStringsSep "\n" (map (dir: ''mkdir -p "${dir}"'') rwDirs);
+  mkFilesStr = builtins.concatStringsSep "\n" (map (file: ''touch "${file}"'') rwFiles);
+  bindDirsStr = builtins.concatStringsSep " " (map (dir: ''--bind "${dir}" "${dir}"'') rwDirs);
+  # Adds each rwDir to the BOUND_PREFIXES shell array at runtime
   stateDirsBoundPrefixBashStr = builtins.concatStringsSep "\n" (
-    map (dir: ''BOUND_PREFIXES+=("${dir}")'') stateDirs
+    map (dir: ''BOUND_PREFIXES+=("${dir}")'') rwDirs
   );
 
   symlinkHelpers = import ./symlink-helpers.nix {
@@ -125,23 +131,23 @@ let
       ${symlinkHelpers.addSymlinkTargetBashStr}
       ${symlinkHelpers.followSymlinkChainBashStr}
 
-      # Resolve stateFile symlinks — bind resolved targets, not the symlink paths
+      # Resolve rwFile symlinks — bind resolved targets, not the symlink paths
       STATE_FILE_BINDS=""
-      ${builtins.concatStringsSep "\n" (map symlinkHelpers.mkResolveFileBashStr stateFiles)}
+      ${builtins.concatStringsSep "\n" (map symlinkHelpers.mkResolveFileBashStr rwFiles)}
 
-      # Scan stateDirs for internal symlinks and bind their resolved targets
-      ${builtins.concatStringsSep "\n" (map symlinkHelpers.mkScanDirBashStr stateDirs)}
+      # Scan rwDirs for internal symlinks and bind their resolved targets
+      ${builtins.concatStringsSep "\n" (map symlinkHelpers.mkScanDirBashStr rwDirs)}
     '';
 
   extraEnvStr = builtins.concatStringsSep " " (
-    map (name: "--setenv ${name} ${builtins.toJSON extraEnv.${name}}") (builtins.attrNames extraEnv)
+    map (name: "--setenv ${name} ${builtins.toJSON env.${name}}") (builtins.attrNames env)
   );
 
   conditionalNetworkingParams = import ./networking.nix {
     pkgs = pkgs;
     shared = shared;
-    restrictNetwork = restrictNetwork;
-    allowedDomains = allowedDomains;
+    restrictNetwork = allowedDomains != null;
+    allowedDomains = if allowedDomains != null then allowedDomains else [ ];
     _proxyRedirects = _proxyRedirects;
   };
 
@@ -214,74 +220,83 @@ let
     '';
 
 in
-pkgs.writeTextFile {
-  name = outName;
-  executable = true;
-  destination = "/bin/${outName}";
-  text =
-    # bash
-    ''
-        #!${pkgs.bashInteractive}/bin/bash
-        CWD=$(pwd)
-        ${conditionalNetworkingParams.warnIgnoredDomainsBashStr}
-        ${mkDirsStr}
-        ${mkFilesStr}
-        ${gitDetectionBashStr}
 
-        # Build per-path ro-bind flags for the nix store closure
-        CLOSURE_BINDS=""
-        BOUND_PREFIXES=()
-        while IFS= read -r storePath; do
-          CLOSURE_BINDS="$CLOSURE_BINDS --ro-bind $storePath $storePath"
-          BOUND_PREFIXES+=("$storePath")
-        done < ${closurePathsFile}
+builtins.seq
+  (shared.assertNoLegacyArgs {
+    restrictNetwork = restrictNetwork;
+    extraEnv = extraEnv;
+    stateDirs = stateDirs;
+    stateFiles = stateFiles;
+  })
+  (
+    pkgs.writeTextFile {
+      name = outName;
+      executable = true;
+      destination = "/bin/${outName}";
+      text =
+        # bash
+        ''
+            #!${pkgs.bashInteractive}/bin/bash
+            CWD=$(pwd)
+            ${mkDirsStr}
+            ${mkFilesStr}
+            ${gitDetectionBashStr}
 
-      ${symlinkResolutionBashStr}
-      ${sandboxPasswdBashStr}
-      ${conditionalNetworkingParams.proxyStartupBashStr}
-      ${trapBashStr}
-      ${conditionalNetworkingParams.sandboxExecBashStr}${pkgs.coreutils}/bin/env -i ${pkgs.bubblewrap}/bin/bwrap \
-        ${conditionalNetworkingParams.etcResolvBind} \
-        --tmpfs /nix/store \
-        $CLOSURE_BINDS \
-        --ro-bind "$_SANDBOX_PASSWD" /etc/passwd \
-        --ro-bind ${hostsFile} /etc/hosts \
-        --ro-bind-try /etc/ssl/certs /etc/ssl/certs \
-        --ro-bind-try /etc/static /etc/static \
-        --ro-bind-try /etc/pki /etc/pki \
-        --proc /proc \
-        --ro-bind ${emptyFile} /proc/cmdline \
-        --ro-bind ${emptyFile} /proc/sys/kernel/random/boot_id \
-        --dev /dev \
-        --tmpfs /tmp \
-        --tmpfs "$HOME" \
-        $REPO_BIND \
-        --bind "$CWD" "$CWD" \
-        ${bindDirsStr} \
-        $STATE_FILE_BINDS \
-        $SYMLINK_PARENT_DIRS \
-        $readonlyStateFileSymlinks \
-        $GIT_BIND \
-        --symlink ${bashWrapper}/bin/bash /bin/sh \
-        --symlink ${pkgs.coreutils}/bin/env /usr/bin/env \
-        --unshare-all \
-        --hostname sandbox \
-        --uid "$(id -u)" \
-        --gid "$(id -g)" \
-        --share-net \
-        --die-with-parent \
-        --chdir "$CWD" \
-        --clearenv \
-        --setenv HOME "$HOME" \
-        --setenv TERM "$TERM" \
-        --setenv SHELL "${bashWrapper}/bin/bash" \
-        --setenv PATH "${pathStr}" \
-        --setenv SSL_CERT_DIR "${pkgs.cacert}/etc/ssl/certs" \
-        --setenv TMPDIR /tmp \
-        ${conditionalNetworkingParams.sslCertEnvBubblewrapStr} \
-        ${conditionalNetworkingParams.caCertBubblewrapStr} \
-        ${conditionalNetworkingParams.proxyEnvBubblewrapStr} \
-        ${extraEnvStr} \
-        ${pkg}/bin/${binName} "$@"
-    '';
-}
+            # Build per-path ro-bind flags for the nix store closure
+            CLOSURE_BINDS=""
+            BOUND_PREFIXES=()
+            while IFS= read -r storePath; do
+              CLOSURE_BINDS="$CLOSURE_BINDS --ro-bind $storePath $storePath"
+              BOUND_PREFIXES+=("$storePath")
+            done < ${closurePathsFile}
+
+          ${symlinkResolutionBashStr}
+          ${sandboxPasswdBashStr}
+          ${conditionalNetworkingParams.proxyStartupBashStr}
+          ${trapBashStr}
+          ${conditionalNetworkingParams.sandboxExecBashStr}${pkgs.coreutils}/bin/env -i ${pkgs.bubblewrap}/bin/bwrap \
+            ${conditionalNetworkingParams.etcResolvBind} \
+            --tmpfs /nix/store \
+            $CLOSURE_BINDS \
+            --ro-bind "$_SANDBOX_PASSWD" /etc/passwd \
+            --ro-bind ${hostsFile} /etc/hosts \
+            --ro-bind-try /etc/ssl/certs /etc/ssl/certs \
+            --ro-bind-try /etc/static /etc/static \
+            --ro-bind-try /etc/pki /etc/pki \
+            --proc /proc \
+            --ro-bind ${emptyFile} /proc/cmdline \
+            --ro-bind ${emptyFile} /proc/sys/kernel/random/boot_id \
+            --dev /dev \
+            --tmpfs /tmp \
+            --tmpfs "$HOME" \
+            $REPO_BIND \
+            --bind "$CWD" "$CWD" \
+            ${bindDirsStr} \
+            $STATE_FILE_BINDS \
+            $SYMLINK_PARENT_DIRS \
+            $readonlyStateFileSymlinks \
+            $GIT_BIND \
+            --symlink ${bashWrapper}/bin/bash /bin/sh \
+            --symlink ${pkgs.coreutils}/bin/env /usr/bin/env \
+            --unshare-all \
+            --hostname sandbox \
+            --uid "$(id -u)" \
+            --gid "$(id -g)" \
+            --share-net \
+            --die-with-parent \
+            --chdir "$CWD" \
+            --clearenv \
+            --setenv HOME "$HOME" \
+            --setenv TERM "$TERM" \
+            --setenv SHELL "${bashWrapper}/bin/bash" \
+            --setenv PATH "${pathStr}" \
+            --setenv SSL_CERT_DIR "${pkgs.cacert}/etc/ssl/certs" \
+            --setenv TMPDIR /tmp \
+            ${conditionalNetworkingParams.sslCertEnvBubblewrapStr} \
+            ${conditionalNetworkingParams.caCertBubblewrapStr} \
+            ${conditionalNetworkingParams.proxyEnvBubblewrapStr} \
+            ${extraEnvStr} \
+            ${pkg}/bin/${binName} "$@"
+        '';
+    }
+  )

--- a/lib/linux/networking.nix
+++ b/lib/linux/networking.nix
@@ -7,7 +7,6 @@
 }:
 let
   mkAllowlistFile = shared.mkAllowlistFile;
-  hasAllowedDomains = shared.hasAllowedDomains;
   mkProxyStartupBashStr = shared.mkProxyStartupBashStr;
   pastaGatewayIp = "10.0.2.2";
   pastaNamespaceIp = "10.0.2.1";
@@ -41,7 +40,6 @@ if restrictNetwork then
     allowlistFileStr = mkAllowlistFile allowedDomains;
   in
   {
-    warnIgnoredDomainsBashStr = "";
     proxyEnvBubblewrapStr = ''--setenv HTTP_PROXY "http://${pastaGatewayIp}:$_PROXY_PORT" --setenv HTTPS_PROXY "http://${pastaGatewayIp}:$_PROXY_PORT" --setenv http_proxy "http://${pastaGatewayIp}:$_PROXY_PORT" --setenv https_proxy "http://${pastaGatewayIp}:$_PROXY_PORT"'';
 
     caCertBubblewrapStr = ''--ro-bind "$_COMBINED_CA_BUNDLE" /tmp/sandbox-ca-bundle.pem --ro-bind "$_CA_CERT_FILE" /tmp/sandbox-ca-cert.pem --setenv SSL_CERT_FILE /tmp/sandbox-ca-bundle.pem --setenv NIX_SSL_CERT_FILE /tmp/sandbox-ca-bundle.pem --setenv NODE_EXTRA_CA_CERTS /tmp/sandbox-ca-cert.pem --setenv REQUESTS_CA_BUNDLE /tmp/sandbox-ca-bundle.pem'';
@@ -58,14 +56,6 @@ if restrictNetwork then
   }
 else
   {
-    warnIgnoredDomainsBashStr =
-      if (hasAllowedDomains allowedDomains) then
-        # bash
-        ''
-          echo "${shared.warnPrefix} allowedDomains is set but restrictNetwork is false — domains will be ignored" >&2
-        ''
-      else
-        "";
     proxyEnvBubblewrapStr = "";
     caCertBubblewrapStr = "";
     proxyStartupBashStr = "";

--- a/lib/shared.nix
+++ b/lib/shared.nix
@@ -46,10 +46,6 @@ let
           allowedDomains;
     in
     pkgs.writeText "sandbox-allowlist.json" (builtins.toJSON attrset);
-  # Returns true if allowedDomains is non-empty (works for both list and attrset).
-  hasAllowedDomains =
-    allowedDomains:
-    if builtins.isList allowedDomains then allowedDomains != [ ] else allowedDomains != { };
   # Internal: serializes _proxyRedirects ({ host = "addr:port"; ... }) to the
   # SANDBOX_PROXY_REDIRECT env var value the proxy expects. Empty redirects
   # produces an empty string so the env var is not set at all in production.
@@ -70,37 +66,70 @@ let
     allowlistFileStr: listenAddr: redirects:
     # bash
     ''
-    # Start the MITM proxy and read its port via FIFO
-    _CA_CERT_FILE=$(mktemp /tmp/sandbox-ca-cert.XXXXXX)
-    _PROXY_PORT_FIFO=$(mktemp -u /tmp/sandbox-proxy-port.XXXXXX)
-    mkfifo "$_PROXY_PORT_FIFO"
-    # Open FIFO read-write so neither side blocks waiting for the other
-    exec 3<> "$_PROXY_PORT_FIFO"
-    ${mkRedirectsEnvBashStr redirects}${sandboxProxy}/bin/sandbox-proxy ${allowlistFileStr} "$_CA_CERT_FILE" ${listenAddr} > "$_PROXY_PORT_FIFO" 2>>/tmp/sandbox-proxy.log &
-    _PROXY_PID=$!
-    # Block until the proxy writes its port (or 5s timeout via background kill)
-    ( sleep 5 && kill -0 $$ 2>/dev/null && echo >&2 "${errorPrefix} sandbox proxy timed out" && kill $$ ) &
-    _TIMEOUT_PID=$!
-    _PROXY_PORT=$(head -1 <&3)
-    exec 3<&-
-    kill $_TIMEOUT_PID 2>/dev/null
-    wait $_TIMEOUT_PID 2>/dev/null || true
-    rm -f "$_PROXY_PORT_FIFO"
-    if [ -z "$_PROXY_PORT" ]; then
-      echo "${errorPrefix} sandbox proxy failed to start (check /tmp/sandbox-proxy.log)" >&2
-      kill $_PROXY_PID 2>/dev/null
-      exit 1
-    fi
-    # Create a combined CA bundle: system certs + proxy's ephemeral CA
-    _COMBINED_CA_BUNDLE=$(mktemp /tmp/sandbox-ca-bundle.XXXXXX)
-    cat ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt "$_CA_CERT_FILE" > "$_COMBINED_CA_BUNDLE"
-  '';
+      # Start the MITM proxy and read its port via FIFO
+      _CA_CERT_FILE=$(mktemp /tmp/sandbox-ca-cert.XXXXXX)
+      _PROXY_PORT_FIFO=$(mktemp -u /tmp/sandbox-proxy-port.XXXXXX)
+      mkfifo "$_PROXY_PORT_FIFO"
+      # Open FIFO read-write so neither side blocks waiting for the other
+      exec 3<> "$_PROXY_PORT_FIFO"
+      ${mkRedirectsEnvBashStr redirects}${sandboxProxy}/bin/sandbox-proxy ${allowlistFileStr} "$_CA_CERT_FILE" ${listenAddr} > "$_PROXY_PORT_FIFO" 2>>/tmp/sandbox-proxy.log &
+      _PROXY_PID=$!
+      # Block until the proxy writes its port (or 5s timeout via background kill)
+      ( sleep 5 && kill -0 $$ 2>/dev/null && echo >&2 "${errorPrefix} sandbox proxy timed out" && kill $$ ) &
+      _TIMEOUT_PID=$!
+      _PROXY_PORT=$(head -1 <&3)
+      exec 3<&-
+      kill $_TIMEOUT_PID 2>/dev/null
+      wait $_TIMEOUT_PID 2>/dev/null || true
+      rm -f "$_PROXY_PORT_FIFO"
+      if [ -z "$_PROXY_PORT" ]; then
+        echo "${errorPrefix} sandbox proxy failed to start (check /tmp/sandbox-proxy.log)" >&2
+        kill $_PROXY_PID 2>/dev/null
+        exit 1
+      fi
+      # Create a combined CA bundle: system certs + proxy's ephemeral CA
+      _COMBINED_CA_BUNDLE=$(mktemp /tmp/sandbox-ca-bundle.XXXXXX)
+      cat ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt "$_CA_CERT_FILE" > "$_COMBINED_CA_BUNDLE"
+    '';
+  assertNoLegacyArgs =
+    {
+      restrictNetwork,
+      extraEnv,
+      stateDirs,
+      stateFiles,
+    }:
+    let
+      legacyArgHints = {
+        restrictNetwork =
+          if restrictNetwork != null then
+            "The 'restrictNetwork' argument is deprecated. Network access is now controlled by 'allowedDomains' alone:\n  - omit it for open internet\n  - set a list/attrset to filter\n  - set to [] to block all\nSee the migration guide: https://github.com/archie-judd/agent-sandbox.nix"
+          else
+            null;
+        extraEnv =
+          if extraEnv != null then "The 'extraEnv' argument is deprecated. Use 'env' instead." else null;
+        stateDirs =
+          if stateDirs != null then "The 'stateDirs' argument is deprecated. Use 'rwDirs' instead." else null;
+        stateFiles =
+          if stateFiles != null then
+            "The 'stateFiles' argument is deprecated. Use 'rwFiles' instead."
+          else
+            null;
+      };
+      throwMsgHints = builtins.concatStringsSep "\n\n" (
+        builtins.attrValues (pkgs.lib.filterAttrs (_: v: v != null) legacyArgHints)
+      );
+      throwMsg = "${errorPrefix} Deprecated arguments:\n\n${throwMsgHints}\n\nPlease update your configuration accordingly.";
+    in
+    if restrictNetwork != null || extraEnv != null || stateDirs != null || stateFiles != null then
+      builtins.throw throwMsg
+    else
+      null;
 in
 {
   bashWrapper = bashWrapper;
   mkAllowlistFile = mkAllowlistFile;
-  hasAllowedDomains = hasAllowedDomains;
   mkProxyStartupBashStr = mkProxyStartupBashStr;
   warnPrefix = warnPrefix;
   errorPrefix = errorPrefix;
+  assertNoLegacyArgs = assertNoLegacyArgs;
 }

--- a/shells/claude-uv.shell.nix
+++ b/shells/claude-uv.shell.nix
@@ -57,15 +57,14 @@ let
     pkg = pkgs.claude-code;
     binName = "claude";
     outName = "claude-sandboxed";
-    stateDirs = [
+    rwDirs = [
       "$HOME/.claude"
       "$HOME/.cache/uv"
       "$HOME/.local/share/uv"
     ];
-    stateFiles = [ ];
+    rwFiles = [ ];
     allowedPackages = commonPackages;
-    extraEnv = commonEnv // pkgs.lib.optionalAttrs isLinux linuxEnv;
-    restrictNetwork = true;
+    env = commonEnv // pkgs.lib.optionalAttrs isLinux linuxEnv;
     # Broader domain scoping than claude.shell.nix: uv needs access to all
     # github.com / githubusercontent.com subdomains, plus PyPI for packages.
     allowedDomains = {
@@ -93,7 +92,7 @@ let
 
   # uv and python3 are repeated here (also in allowedPackages above) so they are
   # available both inside the sandbox and in the outer nix-shell for ad-hoc use.
-  # LD_LIBRARY_PATH / UV_NO_MANAGED_PYTHON are similarly duplicated: extraEnv
+  # LD_LIBRARY_PATH / UV_NO_MANAGED_PYTHON are similarly duplicated: env
   # injects them inside the sandbox, while the attrs below set them in the
   # outer nix-shell where uv may also be invoked directly.
 in

--- a/shells/claude.shell.nix
+++ b/shells/claude.shell.nix
@@ -16,9 +16,9 @@ let
     binName = "claude";
     outName = "claude-sandboxed";
     allowedPackages = agent-sandbox.commonTools;
-    stateDirs = [ "$HOME/.claude" ];
-    stateFiles = [ ];
-    extraEnv = {
+    rwDirs = [ "$HOME/.claude" ];
+    rwFiles = [ ];
+    env = {
       # Pass secrets as shell variable references (e.g. "$TOKEN"), not
       # via builtins.getEnv, so they expand at runtime and stay out of
       # the /nix/store.
@@ -30,7 +30,6 @@ let
       GIT_COMMITTER_NAME = "claude";
       GIT_COMMITTER_EMAIL = "claude@localhost";
     };
-    restrictNetwork = true;
     allowedDomains = {
       "anthropic.com" = "*";
       "claude.com" = "*";

--- a/shells/copilot.shell.nix
+++ b/shells/copilot.shell.nix
@@ -16,19 +16,18 @@ let
     binName = "copilot";
     outName = "copilot-sandboxed";
     allowedPackages = agent-sandbox.commonTools;
-    stateDirs = [
+    rwDirs = [
       "$HOME/.config/github-copilot"
       "$HOME/.copilot"
     ];
-    stateFiles = [ ];
-    extraEnv = {
+    rwFiles = [ ];
+    env = {
       GITHUB_TOKEN = "$GITHUB_TOKEN";
       GIT_AUTHOR_NAME = "copilot";
       GIT_AUTHOR_EMAIL = "copilot@localhost";
       GIT_COMMITTER_NAME = "copilot";
       GIT_COMMITTER_EMAIL = "copilot@localhost";
     };
-    restrictNetwork = true;
     allowedDomains = {
       "githubcopilot.com" = "*";
       "github.com" = "*";

--- a/templates/claude/flake.nix
+++ b/templates/claude/flake.nix
@@ -23,9 +23,9 @@
             binName = "claude";
             outName = "claude-sandboxed"; # or whatever alias you'd like
             allowedPackages = sbx.commonTools;
-            stateDirs = [ "$HOME/.claude" ];
-            stateFiles = [ ];
-            extraEnv = {
+            rwDirs = [ "$HOME/.claude" ];
+            rwFiles = [ ];
+            env = {
               # Pass secrets as shell variable references (e.g. "$TOKEN"), not
               # via builtins.getEnv, so they expand at runtime and stay out of
               # the /nix/store.
@@ -37,7 +37,6 @@
               GIT_COMMITTER_NAME = "claude";
               GIT_COMMITTER_EMAIL = "claude@localhost";
             };
-            restrictNetwork = true;
             allowedDomains = {
               "anthropic.com" = "*";
               "claude.com" = "*";

--- a/templates/copilot/flake.nix
+++ b/templates/copilot/flake.nix
@@ -23,12 +23,12 @@
             binName = "copilot";
             outName = "copilot-sandboxed"; # or whatever alias you'd like
             allowedPackages = sbx.commonTools;
-            stateDirs = [
+            rwDirs = [
               "$HOME/.config/github-copilot"
               "$HOME/.copilot"
             ];
-            stateFiles = [ ];
-            extraEnv = {
+            rwFiles = [ ];
+            env = {
               # Pass secrets as shell variable references (e.g. "$TOKEN"), not
               # via builtins.getEnv, so they expand at runtime and stay out of
               # the /nix/store.
@@ -38,7 +38,6 @@
               GIT_COMMITTER_NAME = "copilot";
               GIT_COMMITTER_EMAIL = "copilot@localhost";
             };
-            restrictNetwork = true;
             allowedDomains = {
               "githubcopilot.com" = "*";
               "github.com" = "*";

--- a/tests/darwin/test-deep-statedir.sh
+++ b/tests/darwin/test-deep-statedir.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Test: ancestor directory traversal for deeply nested stateDirs (Darwin-specific)
+# Test: ancestor directory traversal for deeply nested rwDirs (Darwin-specific)
 # Verifies that file-read-metadata is granted on intermediate directories
-# between $HOME and a stateDir/stateFile target, so that symlink resolution
+# between $HOME and a rwDir/rwFile target, so that symlink resolution
 # from the sandbox HOME can reach the real path through seatbelt.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 source "$SCRIPT_DIR/../lib.sh"
 
-echo "=== Deep stateDir ancestor traversal tests (Darwin) ==="
+echo "=== Deep rwDir ancestor traversal tests (Darwin) ==="
 echo
 
 SANDBOXED=$(nix-build --no-out-link "$SCRIPT_DIR/../fixtures/deep-statedir-sandbox.nix")
@@ -24,7 +24,7 @@ git init -q
 run() { "$SHELL" --norc --noprofile -c "$@" >/dev/null 2>&1; }
 run_output() { "$SHELL" --norc --noprofile -c "$@" 2>/dev/null; }
 
-# The stateDir is "$HOME/.tmp-test-deep-statedir/a/b/c/data".
+# The rwDir is "$HOME/.tmp-test-deep-statedir/a/b/c/data".
 # Intermediate directories that need file-read-metadata for traversal:
 #   $HOME/.tmp-test-deep-statedir
 #   $HOME/.tmp-test-deep-statedir/a
@@ -38,18 +38,18 @@ INTERMEDIATE2="$HOME/.tmp-test-deep-statedir/a"
 INTERMEDIATE3="$HOME/.tmp-test-deep-statedir/a/b"
 INTERMEDIATE4="$HOME/.tmp-test-deep-statedir/a/b/c"
 
-# --- stateDir read/write through sandbox HOME symlink ---
-expect_ok "can write to deep stateDir" \
+# --- rwDir read/write through sandbox HOME symlink ---
+expect_ok "can write to deep rwDir" \
 	"echo test > \"\$HOME/.tmp-test-deep-statedir/a/b/c/data/test.txt\""
-expect_ok "can read from deep stateDir" \
+expect_ok "can read from deep rwDir" \
 	"cat \"\$HOME/.tmp-test-deep-statedir/a/b/c/data/test.txt\" > /dev/null"
-expect_ok "can remove from deep stateDir" \
+expect_ok "can remove from deep rwDir" \
 	"rm \"\$HOME/.tmp-test-deep-statedir/a/b/c/data/test.txt\""
 
-# --- stateFile read/write through sandbox HOME symlink ---
-expect_ok "can write to deep stateFile" \
+# --- rwFile read/write through sandbox HOME symlink ---
+expect_ok "can write to deep rwFile" \
 	"echo '{\"key\":\"val\"}' > \"\$HOME/.tmp-test-deep-statedir/a/b/c/config.json\""
-expect_ok "can read from deep stateFile" \
+expect_ok "can read from deep rwFile" \
 	"cat \"\$HOME/.tmp-test-deep-statedir/a/b/c/config.json\" > /dev/null"
 
 # --- Intermediate directory traversal (stat must succeed) ---

--- a/tests/darwin/test-unix-socket-egress-denied.sh
+++ b/tests/darwin/test-unix-socket-egress-denied.sh
@@ -2,14 +2,15 @@
 # Test: UNIX-socket egress is denied from inside the sandbox. Regression
 # for SANDBOX-FINDINGS.md §2. Seatbelt cannot scope (remote unix-socket)
 # by path, so the unrestricted allow that used to live in
-# networking.nix's restrictNetwork=true branch let the sandboxed
+# networking.nix's filtered (allowedDomains-set) branch let the sandboxed
 # process connect() to any UNIX socket on the host (Alacritty IPC,
 # launchd listeners, ssh-agent, etc.). The fix drops the allow; this
 # test asserts the connect() is denied.
 #
-# The fixture uses restrictNetwork=true on purpose — under
-# restrictNetwork=false the static profile contains (allow network*),
-# which permits AF_UNIX connect and would mask the regression.
+# The fixture sets allowedDomains on purpose (filtered mode) — with
+# allowedDomains omitted (open mode) the static profile contains
+# (allow network*), which permits AF_UNIX connect and would mask the
+# regression.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/tests/fixtures/basic-sandbox.nix
+++ b/tests/fixtures/basic-sandbox.nix
@@ -7,7 +7,7 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash";
   allowedPackages = [ pkgs.coreutils ];
-  stateDirs = [ "$HOME/.test-state-dir" ];
-  stateFiles = [ "$HOME/.test-state-file" ];
-  extraEnv = { TEST_VAR = "test-value"; };
+  rwDirs = [ "$HOME/.test-state-dir" ];
+  rwFiles = [ "$HOME/.test-state-file" ];
+  env = { TEST_VAR = "test-value"; };
 }

--- a/tests/fixtures/deep-statedir-sandbox.nix
+++ b/tests/fixtures/deep-statedir-sandbox.nix
@@ -1,5 +1,5 @@
-# Test fixture: sandbox with a deeply nested stateDir.
-# Exercises ancestor traversal between $HOME and the stateDir target,
+# Test fixture: sandbox with a deeply nested rwDir.
+# Exercises ancestor traversal between $HOME and the rwDir target,
 # ensuring seatbelt grants file-read-metadata on intermediate directories
 # so symlink resolution can reach the allowed path.
 #
@@ -13,6 +13,6 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash-deep-statedir";
   allowedPackages = [ pkgs.coreutils ];
-  stateDirs = [ "$HOME/.tmp-test-deep-statedir/a/b/c/data" ];
-  stateFiles = [ "$HOME/.tmp-test-deep-statedir/a/b/c/config.json" ];
+  rwDirs = [ "$HOME/.tmp-test-deep-statedir/a/b/c/data" ];
+  rwFiles = [ "$HOME/.tmp-test-deep-statedir/a/b/c/config.json" ];
 }

--- a/tests/fixtures/network-allowed.nix
+++ b/tests/fixtures/network-allowed.nix
@@ -11,7 +11,6 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash-net";
   allowedPackages = [ pkgs.coreutils pkgs.bash pkgs.curl ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.iputils ];
-  restrictNetwork = true;
   allowedDomains = [ "httpbin.test" ];
   _proxyRedirects = { "httpbin.test" = "127.0.0.1:${httpbinPort}"; };
 }

--- a/tests/fixtures/network-blocked.nix
+++ b/tests/fixtures/network-blocked.nix
@@ -7,6 +7,5 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash-block";
   allowedPackages = [ pkgs.coreutils pkgs.bash pkgs.curl ];
-  restrictNetwork = true;
   allowedDomains = [ ];
 }

--- a/tests/fixtures/network-method-filtered.nix
+++ b/tests/fixtures/network-method-filtered.nix
@@ -11,7 +11,6 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash-methods";
   allowedPackages = [ pkgs.coreutils pkgs.bash pkgs.curl ];
-  restrictNetwork = true;
   allowedDomains = {
     "httpbin.test" = [ "GET" "HEAD" ];
     "pie.test" = "*";

--- a/tests/fixtures/network-unrestricted.nix
+++ b/tests/fixtures/network-unrestricted.nix
@@ -7,5 +7,4 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash-unres";
   allowedPackages = [ pkgs.coreutils pkgs.bash pkgs.curl ];
-  restrictNetwork = false;
 }

--- a/tests/fixtures/nix-store-isolation.nix
+++ b/tests/fixtures/nix-store-isolation.nix
@@ -1,7 +1,7 @@
 # Test: packages outside the closure are not readable/executable inside the sandbox.
 #
 # We pass the store path of a non-allowed package (hello) into the sandbox via
-# extraEnv. The package is built/fetched by Nix (because it's referenced in the
+# env. The package is built/fetched by Nix (because it's referenced in the
 # expression) but is NOT in allowedPackages, so the sandbox should deny access.
 let
   pkgs = import <nixpkgs> { };
@@ -12,5 +12,5 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash-store-isolation";
   allowedPackages = [ pkgs.coreutils pkgs.bash ];
-  extraEnv = { DISALLOWED_STORE_PATH = "${disallowedPkg}"; };
+  env = { DISALLOWED_STORE_PATH = "${disallowedPkg}"; };
 }

--- a/tests/fixtures/symlinks-sandbox.nix
+++ b/tests/fixtures/symlinks-sandbox.nix
@@ -1,4 +1,4 @@
-# Test fixture: stateDir/stateFile access and symlink resolution
+# Test fixture: rwDir/rwFile access and symlink resolution
 let
   pkgs = import <nixpkgs> { };
   sandbox = import ../../default.nix { pkgs = pkgs; };
@@ -7,9 +7,9 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash-symlinks";
   allowedPackages = [ pkgs.coreutils ];
-  stateDirs = [ "$HOME/.test-state-dir" ];
-  stateFiles = [ "$HOME/.test-state-file" ];
-  extraEnv = {
+  rwDirs = [ "$HOME/.test-state-dir" ];
+  rwFiles = [ "$HOME/.test-state-file" ];
+  env = {
     # A nix store path NOT in the closure — for testing that symlink targets
     # outside the closure are bound read-only. (pkgs.hello is not in
     # allowedPackages, so its store path is inaccessible without symlink resolution.)

--- a/tests/fixtures/unix-socket-client-sandbox.nix
+++ b/tests/fixtures/unix-socket-client-sandbox.nix
@@ -1,12 +1,12 @@
-# Test fixture: restrictNetwork=true sandbox with a UNIX-socket-capable
-# client (socat) in PATH. Used to assert that connect() to a UNIX-domain
-# socket on the host is denied. See
+# Test fixture: filtered-network sandbox (allowedDomains set) with a
+# UNIX-socket-capable client (socat) in PATH. Used to assert that connect()
+# to a UNIX-domain socket on the host is denied. See
 # tests/darwin/test-unix-socket-egress-denied.sh.
 #
-# IMPORTANT: restrictNetwork=true is required for this test. With
-# restrictNetwork=false the static profile contains (allow network*) which
-# permits all socket ops, including AF_UNIX connect — so the regression
-# would silently pass for the wrong reason.
+# IMPORTANT: a non-null allowedDomains (filtered mode) is required for this
+# test. With allowedDomains omitted (open mode) the static profile contains
+# (allow network*) which permits all socket ops, including AF_UNIX connect —
+# so the regression would silently pass for the wrong reason.
 let
   pkgs = import <nixpkgs> { };
   sandbox = import ../../default.nix { pkgs = pkgs; };
@@ -15,6 +15,5 @@ in sandbox.mkSandbox {
   binName = "bash";
   outName = "sandboxed-bash";
   allowedPackages = [ pkgs.coreutils pkgs.socat ];
-  restrictNetwork = true;
   allowedDomains = [ "anthropic.com" ];
 }

--- a/tests/linux/test-network.sh
+++ b/tests/linux/test-network.sh
@@ -8,13 +8,13 @@ source "$SCRIPT_DIR/../lib.sh"
 echo "=== Network restriction tests (Linux) ==="
 echo
 
-# Build a sandbox with restrictNetwork=true and one allowed domain
+# Build a sandbox with one allowed domain
 SANDBOXED_NET=$(nix-build --no-out-link "$SCRIPT_DIR/../fixtures/network-allowed.nix")
 NET_SHELL="$SANDBOXED_NET/bin/sandboxed-bash-net"
 run() { "$NET_SHELL" --norc --noprofile -c "$@" >/dev/null 2>&1; }
 
-# Linux only: DNS resolution is blocked when restrictNetwork=true
-expect_fail "DNS resolution blocked when restrictNetwork=true" \
+# Linux only: DNS resolution is blocked when allowedDomains is set (filtered mode)
+expect_fail "DNS resolution blocked when allowedDomains is set" \
 	'getent hosts example.com'
 
 # Test: sandbox cannot reach the proxy host on non-proxy TCP ports.

--- a/tests/linux/test-symlinks.sh
+++ b/tests/linux/test-symlinks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# stateDir/stateFile access and symlink resolution tests (Linux-specific)
+# rwDir/rwFile access and symlink resolution tests (Linux-specific)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -21,13 +21,13 @@ echo "out-of-bounds content" > "$OOB_FILE"
 trap 'rm -rf "$TESTDIR" "$OOB_FILE"' EXIT
 cd "$TESTDIR"
 
-echo "=== stateDir/stateFile and symlink resolution tests (Linux) ==="
+echo "=== rwDir/rwFile and symlink resolution tests (Linux) ==="
 echo
 
-# --- stateDirs / stateFiles (regression: non-symlink paths) ---
-expect_ok "can write to stateDir" "echo test > \$HOME/.test-state-dir/file && cat \$HOME/.test-state-dir/file"
-expect_ok "can write to stateFile" "echo test > \$HOME/.test-state-file && cat \$HOME/.test-state-file"
-expect_fail "stateDir does not weaken isolation" "ls \$HOME/.ssh"
+# --- rwDirs / rwFiles (regression: non-symlink paths) ---
+expect_ok "can write to rwDir" "echo test > \$HOME/.test-state-dir/file && cat \$HOME/.test-state-dir/file"
+expect_ok "can write to rwFile" "echo test > \$HOME/.test-state-file && cat \$HOME/.test-state-file"
+expect_fail "rwDir does not weaken isolation" "ls \$HOME/.ssh"
 
 # Retrieve store paths baked into the sandbox at build time
 CLOSURE_STORE_FILE=$(run_output 'echo $CLOSURE_STORE_FILE')
@@ -36,42 +36,42 @@ NONCLOSURE_STORE_FILE=$(run_output 'echo $NONCLOSURE_STORE_FILE')
 REAL_FILE="$TESTDIR/real-target-file"
 echo "real content" > "$REAL_FILE"
 
-# --- Test A: stateFile is a symlink to an out-of-bounds path is rejected ---
+# --- Test A: rwFile is a symlink to an out-of-bounds path is rejected ---
 rm -f "$HOME/.test-state-file"
 ln -sfn "$OOB_FILE" "$HOME/.test-state-file"
 
-expect_fail "stateFile symlink to out-of-bounds path: target not accessible (security)" "cat $OOB_FILE"
-expect_ok  "stateFile symlink to out-of-bounds path: sandbox still starts cleanly" "echo ok"
+expect_fail "rwFile symlink to out-of-bounds path: target not accessible (security)" "cat $OOB_FILE"
+expect_ok  "rwFile symlink to out-of-bounds path: sandbox still starts cleanly" "echo ok"
 
-# --- Test B: stateFile is a symlink to a nix store file (in closure) ---
+# --- Test B: rwFile is a symlink to a nix store file (in closure) ---
 rm -f "$HOME/.test-state-file"
 ln -sfn "$CLOSURE_STORE_FILE" "$HOME/.test-state-file"
 
-expect_ok "stateFile symlink to in-closure store file: readable" "cat \$CLOSURE_STORE_FILE"
+expect_ok "rwFile symlink to in-closure store file: readable" "cat \$CLOSURE_STORE_FILE"
 
-# --- Test C: stateDir symlink to out-of-bounds path is rejected ---
+# --- Test C: rwDir symlink to out-of-bounds path is rejected ---
 # Symlinks that point outside /nix/store (and paths already in BOUND_PREFIXES)
 # are silently ignored at startup. An agent could otherwise plant a symlink
 # during a session to expand the sandbox on the next startup
 # (e.g. ~/.claude/evil -> /etc/shadow).
-# Users who need such a target must declare it explicitly as a stateDir or stateFile.
+# Users who need such a target must declare it explicitly as a rwDir or rwFile.
 rm -f "$HOME/.test-state-file"; touch "$HOME/.test-state-file"
 mkdir -p "$HOME/.test-state-dir"
 ln -sfn "$OOB_FILE" "$HOME/.test-state-dir/link-to-oob"
 
-expect_fail "stateDir symlink to out-of-bounds path: target not accessible (security)" "cat $OOB_FILE"
-expect_ok  "stateDir symlink to out-of-bounds path: sandbox still starts cleanly" "echo ok"
+expect_fail "rwDir symlink to out-of-bounds path: target not accessible (security)" "cat $OOB_FILE"
+expect_ok  "rwDir symlink to out-of-bounds path: sandbox still starts cleanly" "echo ok"
 
-# --- Test D: stateDir contains a symlink to a nix store file NOT in closure ---
+# --- Test D: rwDir contains a symlink to a nix store file NOT in closure ---
 ln -sfn "$NONCLOSURE_STORE_FILE" "$HOME/.test-state-dir/link-to-nonclosure"
 
-expect_ok "stateDir symlink to non-closure store file: readable" "test -e \$NONCLOSURE_STORE_FILE"
-expect_fail "stateDir symlink to non-closure store file: not writable" "echo x >> \$NONCLOSURE_STORE_FILE"
+expect_ok "rwDir symlink to non-closure store file: readable" "test -e \$NONCLOSURE_STORE_FILE"
+expect_fail "rwDir symlink to non-closure store file: not writable" "echo x >> \$NONCLOSURE_STORE_FILE"
 
-# --- Test E: stateDir contains a symlink to a nix store file already in closure ---
+# --- Test E: rwDir contains a symlink to a nix store file already in closure ---
 ln -sfn "$CLOSURE_STORE_FILE" "$HOME/.test-state-dir/link-to-closure"
 
-expect_ok "stateDir symlink to in-closure store file: readable" "cat \$CLOSURE_STORE_FILE"
+expect_ok "rwDir symlink to in-closure store file: readable" "cat \$CLOSURE_STORE_FILE"
 
 # --- Test F: deduplication: two symlinks to the same Nix store target ---
 # Both symlinks point at the same non-closure store path; bwrap must only
@@ -90,7 +90,7 @@ rm -f "$HOME/.test-state-dir/link-to-oob" \
       "$HOME/.test-state-dir/dup-link-1" \
       "$HOME/.test-state-dir/dup-link-2"
 
-# --- Test H: stateDir double-symlink chain with an out-of-bounds intermediate ---
+# --- Test H: rwDir double-symlink chain with an out-of-bounds intermediate ---
 # Both the intermediate path (/tmp/...) and the final target are outside
 # the permitted sandbox paths, so the first hop is rejected and the chain
 # is not bound. The sandbox still starts cleanly.

--- a/tests/shared/test-basic.sh
+++ b/tests/shared/test-basic.sh
@@ -31,19 +31,19 @@ expect_ok "can write to /tmp" "touch /tmp/sandbox-test && rm /tmp/sandbox-test"
 expect_ok "can read /etc/resolv.conf" "cat /etc/resolv.conf > /dev/null"
 expect_ok "can run allowed binaries" "ls / > /dev/null"
 
-# --- stateDirs / stateFiles / extraEnv ---
+# --- rwDirs / rwFiles / env ---
 if [ "$(run_output 'echo $TEST_VAR')" = "test-value" ]; then
-	echo "PASS: extraEnv variable is accessible"
+	echo "PASS: env variable is accessible"
 	PASS=$((PASS + 1))
 else
-	echo "FAIL: extraEnv variable not accessible"
+	echo "FAIL: env variable not accessible"
 	FAIL=$((FAIL + 1))
 fi
 
 # --- Environment isolation (env -i) ---
 export _TEST_HOST_VAR="should-not-propagate"
 if [ -z "$(run_output 'echo $_TEST_HOST_VAR')" ]; then
-	echo "PASS: host env vars not in extraEnv are not propagated"
+	echo "PASS: host env vars not in env are not propagated"
 	PASS=$((PASS + 1))
 else
 	echo "FAIL: host env var leaked into sandbox"

--- a/tests/shared/test-legacy-args-error.sh
+++ b/tests/shared/test-legacy-args-error.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Legacy-argument migration errors (shared across platforms).
+#
+# Each removed/renamed mkSandbox argument (extraEnv, stateDirs, stateFiles,
+# restrictNetwork) must fail at *eval* time with the migration message from
+# shared.assertNoLegacyArgs — never silently build under the old name.
+#
+# We force the wrapper to WHNF with `builtins.seq wrapper "ok"`, which fires
+# the assertNoLegacyArgs `seq` guard without realising the derivation (so no
+# closure is built — the eval stays cheap).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+source "$SCRIPT_DIR/../lib.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Evaluate mkSandbox with the given extra argument(s) spliced in. Returns
+# nix-instantiate's exit code; stderr is folded into stdout for inspection.
+eval_with() {
+	local extra_args="$1"
+	nix-instantiate --eval -E "
+    let
+      pkgs = import <nixpkgs> { };
+      sandbox = import ${REPO_ROOT}/default.nix { inherit pkgs; };
+      wrapper = sandbox.mkSandbox {
+        pkg = pkgs.bashInteractive;
+        binName = \"bash\";
+        outName = \"legacy-args-test\";
+        allowedPackages = [ pkgs.coreutils ];
+        ${extra_args}
+      };
+    in builtins.seq wrapper \"ok\"
+  " 2>&1
+}
+
+# Assert that splicing `$extra` makes eval fail AND that the throw message
+# contains `$needle` (so we know it failed for the migration reason, not some
+# unrelated eval error).
+expect_legacy_throw() {
+	local desc="$1" extra="$2" needle="$3"
+	local out
+	if out=$(eval_with "$extra"); then
+		echo "FAIL: $desc (eval succeeded; expected a migration error)"
+		FAIL=$((FAIL + 1))
+	elif printf '%s' "$out" | grep -qF "$needle"; then
+		echo "PASS: $desc"
+		PASS=$((PASS + 1))
+	else
+		echo "FAIL: $desc (threw, but message missing: $needle)"
+		printf '%s\n' "$out" | sed 's/^/    /'
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+echo "=== Legacy argument migration errors (shared) ==="
+echo
+
+# Control: a valid call (no legacy args) must evaluate cleanly. Guards against
+# the throw cases passing for the wrong reason (e.g. a broken expression that
+# would fail no matter what).
+if eval_with '' >/dev/null; then
+	echo "PASS: valid config evaluates without error"
+	PASS=$((PASS + 1))
+else
+	echo "FAIL: valid config did not evaluate cleanly"
+	eval_with '' | sed 's/^/    /' || true
+	FAIL=$((FAIL + 1))
+fi
+
+expect_legacy_throw "extraEnv is rejected with migration hint" \
+	'extraEnv = { };' "Use 'env' instead."
+expect_legacy_throw "stateDirs is rejected with migration hint" \
+	'stateDirs = [ ];' "Use 'rwDirs' instead."
+expect_legacy_throw "stateFiles is rejected with migration hint" \
+	'stateFiles = [ ];' "Use 'rwFiles' instead."
+expect_legacy_throw "restrictNetwork is rejected with migration hint" \
+	'restrictNetwork = true;' "'restrictNetwork' argument is deprecated"
+
+print_results
+exit_status

--- a/tests/shared/test-network.sh
+++ b/tests/shared/test-network.sh
@@ -38,7 +38,7 @@ fi
 
 # --- Backward-compat list-format tests ---
 
-# Build a sandbox with restrictNetwork=true and one allowed domain (list format)
+# Build a sandbox with one allowed domain (list format)
 SANDBOXED_NET=$(nix-build --no-out-link --argstr httpbinPort "$LOCAL_HTTPBIN_PORT" "$SCRIPT_DIR/../fixtures/network-allowed.nix")
 NET_SHELL="$SANDBOXED_NET/bin/sandboxed-bash-net"
 run() { "$NET_SHELL" --norc --noprofile -c "$@" >/dev/null 2>&1; }


### PR DESCRIPTION
Rename public arguments: extraEnv → env, stateDirs → rwDirs, stateFiles → rwFiles. Remove restrictNetwork; network mode is now derived from allowedDomains. Legacy argument names throw an eval-time error.

BREAKING CHANGE: Renamed extraEnv → env. Pure rename; semantics unchanged.

BREAKING CHANGE: Renamed stateDirs → rwDirs and stateFiles → rwFiles. Pure rename; semantics unchanged.

BREAKING CHANGE: Removed restrictNetwork. Set allowedDomains = null (or omit it) for unrestricted internet; populate it to filter; [] blocks all. See the migration guide.