### PR TITLE
Prevent warning on darwin about stripped whitespace

### DIFF
--- a/lib/darwin/networking.nix
+++ b/lib/darwin/networking.nix
@@ -9,11 +9,9 @@ let
   mkAllowlistFile = shared.mkAllowlistFile;
   mkProxyStartupBashStr = shared.mkProxyStartupBashStr;
   darwinAllowedLocalPortsRulesStr =
-    if allowedLocalPorts == null then
-      ''        (allow network-outbound (remote ip "localhost:*"))''
-    else
       builtins.concatStringsSep "\n" (
-        map (port: ''        (allow network-outbound (remote ip "localhost:${toString port}"))'') allowedLocalPorts
+        map (port: "        (allow network-outbound (remote ip \"localhost:${port}\"))")
+          (if allowedLocalPorts == null then ["*"] else map toString allowedLocalPorts)
       );
 in
 if allowedDomains != null then


### PR DESCRIPTION
e.g.
```
warning: Whitespace in a ''-string will be stripped even if the string only has a single line, which is most likely not the intent of the code. To fix this, remove the whitespace or replace the string with " instead. Use --extra-deprecated-features broken-string-indentation to silence this warning.
         at /nix/store/wlmd6zd56mgijr2wdpql18r1mkm9vlrm-source/lib/darwin/networking.nix:13:7:
             12|     if allowedLocalPorts == null then
             13|       ''        (allow network-outbound (remote ip "localhost:*"))''
               |       ^
             14|     else
```
