### PR TITLE
fix: silently skip missing bind paths instead of hard-erroring

### DIFF
--- a/lib/linux/default.nix
+++ b/lib/linux/default.nix
@@ -115,14 +115,26 @@ let
     ::1       localhost
   '';
   pathStr = pkgs.lib.makeBinPath (allowedPackages ++ implicitPackages);
-  bindDirsStr = builtins.concatStringsSep " " (map (dir: ''--bind "${dir}" "${dir}"'') rwDirs);
-  bindRoDirsStr = builtins.concatStringsSep " " (map (dir: ''--ro-bind "${dir}" "${dir}"'') roDirs);
-  # Adds each rwDir / roDir to the BOUND_PREFIXES shell array at runtime
+  # Runtime-computed: only bind dirs that actually exist. Missing dirs have
+  # already been warned about by assertBindsExistBashStr; skipping them here
+  # prevents bwrap from aborting on a --bind for a non-existent source path.
+  bindDirsBashStr =
+    let
+      mkEntry = dir: ''[ -e "${dir}" ] && _BIND_DIRS+=(--bind "${dir}" "${dir}")'';
+    in
+    builtins.concatStringsSep "\n" (map mkEntry rwDirs);
+  bindRoDirsBashStr =
+    let
+      mkEntry = dir: ''[ -e "${dir}" ] && _BIND_RO_DIRS+=(--ro-bind "${dir}" "${dir}")'';
+    in
+    builtins.concatStringsSep "\n" (map mkEntry roDirs);
+  # Adds each rwDir / roDir to the BOUND_PREFIXES shell array at runtime,
+  # guarded so missing dirs are not advertised as bound prefixes.
   stateDirsBoundPrefixBashStr = builtins.concatStringsSep "\n" (
-    map (dir: ''BOUND_PREFIXES+=("${dir}")'') rwDirs
+    map (dir: ''[ -e "${dir}" ] && BOUND_PREFIXES+=("${dir}")'') rwDirs
   );
   roDirsBoundPrefixBashStr = builtins.concatStringsSep "\n" (
-    map (dir: ''BOUND_PREFIXES+=("${dir}")'') roDirs
+    map (dir: ''[ -e "${dir}" ] && BOUND_PREFIXES+=("${dir}")'') roDirs
   );
 
   symlinkHelpers = import ./symlink-helpers.nix {
@@ -306,6 +318,10 @@ builtins.seq
           ${conditionalNetworkingParams.proxyStartupBashStr}
           ${conditionalNetworkingParams.resolvConfSetupBashStr}
           ${trapBashStr}
+          _BIND_DIRS=()
+          ${bindDirsBashStr}
+          _BIND_RO_DIRS=()
+          ${bindRoDirsBashStr}
           ${conditionalNetworkingParams.sandboxExecBashStr}${pkgs.coreutils}/bin/env -i ${pkgs.bubblewrap}/bin/bwrap \
             ${conditionalNetworkingParams.etcResolvBind} \
             ${nixStoreBwrapStr} \
@@ -322,8 +338,8 @@ builtins.seq
             --tmpfs "$HOME" \
             $REPO_BIND \
             --bind "$CWD" "$CWD" \
-            ${bindDirsStr} \
-            ${bindRoDirsStr} \
+            "''${_BIND_DIRS[@]}" \
+            "''${_BIND_RO_DIRS[@]}" \
             $STATE_FILE_BINDS \
             $RO_FILE_BINDS \
             $SYMLINK_PARENT_DIRS \

--- a/lib/linux/symlink-helpers.nix
+++ b/lib/linux/symlink-helpers.nix
@@ -123,7 +123,7 @@
           STATE_FILE_BINDS="$STATE_FILE_BINDS --bind $_final ${file}"
           _ensure_parent_dirs "${file}"
         fi
-      else
+      elif [[ -e "${file}" ]]; then
         STATE_FILE_BINDS="$STATE_FILE_BINDS --bind ${file} ${file}"
       fi
     '';
@@ -140,7 +140,7 @@
           RO_FILE_BINDS="$RO_FILE_BINDS --ro-bind $_final ${file}"
           _ensure_parent_dirs "${file}"
         fi
-      else
+      elif [[ -e "${file}" ]]; then
         RO_FILE_BINDS="$RO_FILE_BINDS --ro-bind ${file} ${file}"
       fi
     '';

--- a/lib/shared.nix
+++ b/lib/shared.nix
@@ -91,14 +91,9 @@ let
       _COMBINED_CA_BUNDLE=$(mktemp /tmp/sandbox-ca-bundle.XXXXXX)
       cat ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt "$_CA_CERT_FILE" > "$_COMBINED_CA_BUNDLE"
     '';
-  # Emits a bash snippet that checks every declared rwDir / rwFile exists on
-  # the host before the sandbox launches. Missing paths are accumulated and
-  # reported in one go; the snippet exits 1 if any were missing. Uses
-  # `[ -e ]` so a broken symlink also counts as missing — the wrapper used
-  # to silently `mkdir -p` / `touch` declared paths, which masked typos
-  # like `rwDirs = [ "$HOME/.cluade" ]` as new state directories. The
-  # check is emitted as bash (not evaluated in Nix) because paths reference
-  # shell vars (`$HOME`, etc.) that are only resolved at runtime.
+  # All declared bind paths (rwDirs, rwFiles, roDirs, roFiles) that don't
+  # exist on the host are silently skipped — they just won't be bound.
+  # Kept as a function so call sites need no changes.
   assertBindsExistBashStr =
     {
       rwDirs,
@@ -106,30 +101,7 @@ let
       roDirs ? [ ],
       roFiles ? [ ],
     }:
-    let
-      mkCheck =
-        label: p:
-        # bash
-        ''
-          if [ ! -e "${p}" ]; then
-            echo "${errorPrefix} ${p}: declared as ${label} but does not exist" >&2
-            _BIND_MISSING=1
-          fi'';
-      allChecks = builtins.concatStringsSep "\n" (
-        map (mkCheck "rwDir") rwDirs
-        ++ map (mkCheck "rwFile") rwFiles
-        ++ map (mkCheck "roDir") roDirs
-        ++ map (mkCheck "roFile") roFiles
-      );
-    in
-    # bash
-    ''
-      _BIND_MISSING=0
-      ${allChecks}
-      if [ "$_BIND_MISSING" -ne 0 ]; then
-        exit 1
-      fi
-    '';
+    "";
   validateAllowedLocalPorts =
     allowedLocalPorts:
     if allowedLocalPorts == null then

--- a/tests/shared/test-bind-must-exist.sh
+++ b/tests/shared/test-bind-must-exist.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
-# Test: declared rwDirs / rwFiles must exist on the host before the sandbox
-# launches.
-#
-# The wrapper used to silently `mkdir -p` declared rwDirs and `touch` declared
-# rwFiles at launch. That hid typos like `rwDirs = [ "$HOME/.cluade" ]` — the
-# agent would populate the misspelled directory and the real ~/.claude config
-# would diverge silently. After this change the wrapper checks each declared
-# path with `[ -e ]` (so broken symlinks also fail), accumulates every missing
-# path, prints one error line per miss, and exits 1 before any sandboxing runs.
+# Test: missing rwDirs, rwFiles, roDirs, roFiles are silently skipped —
+# the sandbox launches regardless of whether declared paths exist.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -22,45 +15,35 @@ TESTDIR=$(mktemp -d "$TESTDIR_ROOT/bind-must-exist.XXXXXX")
 trap 'rm -rf "$TESTDIR"' EXIT
 cd "$TESTDIR"
 
-# HOME is overridden per-invocation so the existence of the declared
-# rwDir/rwFile is entirely controlled by this test, independent of the
-# host's real $HOME contents.
 FAKE_HOME="$TESTDIR/home"
 mkdir -p "$FAKE_HOME"
 
 DIR_PATH="$FAKE_HOME/.agent-sandbox-bind-must-exist/dir"
 FILE_PATH="$FAKE_HOME/.agent-sandbox-bind-must-exist/file"
 
-echo "=== Bind paths must exist (shared) ==="
+echo "=== Missing bind paths are silently skipped (shared) ==="
 echo
 
-# --- 1. Both missing: both errors reported in one launch ---
-capture env HOME="$FAKE_HOME" "$SHELL_BIN" -c 'echo unreachable'
-assert_exit_code "both missing: launch fails" 1
-assert_stderr_contains "both missing: rwDir error reported" \
-	"$DIR_PATH: declared as rwDir but does not exist"
-assert_stderr_contains "both missing: rwFile error reported" \
-	"$FILE_PATH: declared as rwFile but does not exist"
+# --- 1. Both missing: launch still succeeds, no output ---
+capture env HOME="$FAKE_HOME" "$SHELL_BIN" -c 'echo ok'
+assert_exit_code "both missing: launch succeeds" 0
+assert_output_equals "both missing: command runs in sandbox" "ok"
+assert_stderr_not_contains "both missing: no output about rwDir" "rwDir"
+assert_stderr_not_contains "both missing: no output about rwFile" "rwFile"
 
 # --- 2. Only rwDir missing ---
 mkdir -p "$(dirname "$FILE_PATH")"
 touch "$FILE_PATH"
-capture env HOME="$FAKE_HOME" "$SHELL_BIN" -c 'echo unreachable'
-assert_exit_code "rwDir missing only: launch fails" 1
-assert_stderr_contains "rwDir missing only: rwDir error reported" \
-	"$DIR_PATH: declared as rwDir but does not exist"
-assert_stderr_not_contains "rwDir missing only: no rwFile error" \
-	"declared as rwFile"
+capture env HOME="$FAKE_HOME" "$SHELL_BIN" -c 'echo ok'
+assert_exit_code "rwDir missing only: launch succeeds" 0
+assert_output_equals "rwDir missing only: command runs in sandbox" "ok"
 
 # --- 3. Only rwFile missing ---
 rm -f "$FILE_PATH"
 mkdir -p "$DIR_PATH"
-capture env HOME="$FAKE_HOME" "$SHELL_BIN" -c 'echo unreachable'
-assert_exit_code "rwFile missing only: launch fails" 1
-assert_stderr_contains "rwFile missing only: rwFile error reported" \
-	"$FILE_PATH: declared as rwFile but does not exist"
-assert_stderr_not_contains "rwFile missing only: no rwDir error" \
-	"declared as rwDir"
+capture env HOME="$FAKE_HOME" "$SHELL_BIN" -c 'echo ok'
+assert_exit_code "rwFile missing only: launch succeeds" 0
+assert_output_equals "rwFile missing only: command runs in sandbox" "ok"
 
 # --- 4. All present: launch succeeds ---
 touch "$FILE_PATH"


### PR DESCRIPTION
## Summary

#61 (in the 2.0.0 release) made it a hard error for any declared `rwDirs`/`roDirs`/`rwFiles`/`roFiles` to be missing on the host at launch, to catch typos like `rwDirs = [ "$HOME/.cluade" ]`. That's a reasonable default, but it's disruptive for configs shared across machines and projects: directories in `rwDirs`/`roDirs` are frequently optional or machine-dependent (cache dirs, tool config dirs that only exist after first run, per-project paths), and failing the whole sandbox launch because one of them hasn't been created yet on this particular machine is painful.

This change relaxes that: all declared bind paths are treated as best-effort. Paths that exist are bound; paths that don't are silently skipped, and the sandbox launches normally.

This is a deliberate trade-off, not a bug fix — it gives up the fail-fast typo detection #61 intentionally added in exchange for tolerating optional paths without noise. You may prefer a middle ground: this repo's git history contains an intermediate commit that instead emits a WARN for missing dirs while keeping missing files a hard error. Happy to split that out or reintroduce warnings if you'd rather not go fully silent.

## Implementation

- `lib/shared.nix`: `assertBindsExistBashStr` is now a no-op (returns `""`).
- `lib/linux/default.nix`: `bindDirsStr`/`bindRoDirsStr` replaced with runtime bash arrays that only include paths verified to exist, so bwrap never gets a `--bind` for a missing source (which would abort it).
- `lib/linux/symlink-helpers.nix`: file binds guarded with an `-e` check so missing `rwFiles`/`roFiles` don't abort bwrap.
- `tests/shared/test-bind-must-exist.sh`: rewritten to assert the silent-skip behavior.
