### PR TITLE
feat: add allowGpu option for /dev/dri passthrough (Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Everything else is denied. `$HOME` is an ephemeral writable tmpfs that disappear
     * [Git identity](#git-identity)
     * [Read-only paths in the git directory](#read-only-paths-in-the-git-directory)
 * [Using Nix inside the sandbox](#using-nix-inside-the-sandbox)
+* [Using GPU acceleration inside the sandbox](#using-gpu-acceleration-inside-the-sandbox)
 * [Common patterns / recipes](#common-patterns--recipes)
     * [Python with uv](#python-with-uv)
     * [Node.js with npm](#nodejs-with-npm)
@@ -125,6 +126,7 @@ If you want to keep the original command name as the alias, change the `outName`
 | `roDirs` | no | Directories the agent can read but not write (e.g. signed binaries, reference source trees, secret stores) |
 | `roFiles` | no | Individual files the agent can read but not write (e.g. `~/.config/git/config` for git identity — see [Git identity](#git-identity)) |
 | `allowNix` | no | If `true`, expose the host's `nix-daemon` socket and the full Nix store so the agent can run `nix build`, `nix run`, `nix develop`, etc. `pkgs.nix` is added to PATH automatically. Defaults to `false`. See [Using Nix inside the sandbox](#using-nix-inside-the-sandbox). |
+| `allowGpu` | no | Linux only. If `true`, bind-mount the host's `/dev/dri` (DRM render/card nodes) into the sandbox so GPU-dependent programs get hardware acceleration. Defaults to `false`. See [Using GPU acceleration inside the sandbox](#using-gpu-acceleration-inside-the-sandbox). |
 | `env` | no | Additional environment variables as an attrset |
 | `allowedDomains` | no | Limits which domains the sandbox can reach. Leave unset for open internet. Accepts a list of domains (all methods allowed), or an attrset mapping each domain to `"*"` or a list of HTTP methods. `[ ]` blocks all internet access. |
 | `allowedLocalPorts` | no | Host-local TCP ports the sandbox may reach. Defaults to `[ ]`. Set to `null` to allow all host-local TCP ports. Otherwise, entries must be integers from `1` to `65535`. |
@@ -345,6 +347,22 @@ What you need to configure:
 A complete example is at [`shells/claude-nix.shell.nix`](shells/claude-nix.shell.nix).
 
 > **Security note:** `allowNix = true` weakens the security posture of the sandbox. The full Nix store is exposed and any executable in the nix store can be run by the agent — `allowedPackages` no longer restricts what the agent can *execute*, only what's on `PATH`. The `nix-daemon` runs outside the sandbox, so its own network activity — downloads of prebuilt packages from the caches it's configured to use — bypasses `allowedDomains`.
+
+## Using GPU acceleration inside the sandbox
+
+Set `allowGpu = true` (Linux only) to bind-mount the host's `/dev/dri` (DRM render + card nodes) into the sandbox. Without it, GPU-dependent programs (browsers doing WebGL/GPU compositing, video encoders, ML inference, etc.) fall back to software rendering.
+
+```nix
+allowGpu = true;
+```
+
+What you need to know:
+
+- **Host permissions still apply.** The sandbox only makes an already-accessible device visible inside the sandbox — it does not grant new permissions. The invoking host user needs pre-existing access to the render node, typically via membership in the host's `render` or `video` group.
+- **Missing device is not an error.** If the host has no `/dev/dri` (no GPU, or running under a display manager without DRI), the bind is skipped silently and the sandbox launches normally, falling back to software rendering.
+- **macOS:** `sandbox-exec`'s policy model restricts syscalls by path, not by device node visibility, so GPU access on macOS is unaffected by sandboxing and `allowGpu` is a no-op there.
+
+> **Security note:** `/dev/dri` exposes the DRM render node, which on most systems is scoped to compute/rendering only (no display/mode-setting capability) and is the same node already reachable by any other unprivileged process in the host's `render` group. This is a materially smaller exposure than `allowNix = true`, but still widens the sandbox's device access beyond the default (no devices besides `/dev/null`, `/dev/zero`, `/dev/random`, etc.).
 
 ## Common patterns / recipes
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you want to keep the original command name as the alias, change the `outName`
 | `roDirs` | no | Directories the agent can read but not write (e.g. signed binaries, reference source trees, secret stores) |
 | `roFiles` | no | Individual files the agent can read but not write (e.g. `~/.config/git/config` for git identity — see [Git identity](#git-identity)) |
 | `allowNix` | no | If `true`, expose the host's `nix-daemon` socket and the full Nix store so the agent can run `nix build`, `nix run`, `nix develop`, etc. `pkgs.nix` is added to PATH automatically. Defaults to `false`. See [Using Nix inside the sandbox](#using-nix-inside-the-sandbox). |
-| `allowGpu` | no | Linux only. If `true`, bind-mount the host's `/dev/dri` (DRM render/card nodes) into the sandbox so GPU-dependent programs get hardware acceleration. Defaults to `false`. See [Using GPU acceleration inside the sandbox](#using-gpu-acceleration-inside-the-sandbox). |
+| `allowGpu` | no | Linux only. If `true`, bind-mount the host's `/dev/dri` (DRM render/card nodes) and read-only `/sys` into the sandbox so GPU-dependent programs get hardware acceleration. Defaults to `false`. See [Using GPU acceleration inside the sandbox](#using-gpu-acceleration-inside-the-sandbox). |
 | `env` | no | Additional environment variables as an attrset |
 | `allowedDomains` | no | Limits which domains the sandbox can reach. Leave unset for open internet. Accepts a list of domains (all methods allowed), or an attrset mapping each domain to `"*"` or a list of HTTP methods. `[ ]` blocks all internet access. |
 | `allowedLocalPorts` | no | Host-local TCP ports the sandbox may reach. Defaults to `[ ]`. Set to `null` to allow all host-local TCP ports. Otherwise, entries must be integers from `1` to `65535`. |
@@ -350,7 +350,7 @@ A complete example is at [`shells/claude-nix.shell.nix`](shells/claude-nix.shell
 
 ## Using GPU acceleration inside the sandbox
 
-Set `allowGpu = true` (Linux only) to bind-mount the host's `/dev/dri` (DRM render + card nodes) into the sandbox. Without it, GPU-dependent programs (browsers doing WebGL/GPU compositing, video encoders, ML inference, etc.) fall back to software rendering.
+Set `allowGpu = true` (Linux only) to bind-mount the host's `/dev/dri` (DRM render + card nodes) and `/sys` into the sandbox. Without it, GPU-dependent programs (browsers doing WebGL/GPU compositing, video encoders, ML inference, etc.) fall back to software rendering.
 
 ```nix
 allowGpu = true;
@@ -359,10 +359,11 @@ allowGpu = true;
 What you need to know:
 
 - **Host permissions still apply.** The sandbox only makes an already-accessible device visible inside the sandbox — it does not grant new permissions. The invoking host user needs pre-existing access to the render node, typically via membership in the host's `render` or `video` group.
+- **`/sys` is bound too, read-only.** GPU detection (Mesa's libdrm, and Chromium's own GPU info collector) resolves a DRM device's PCI vendor/device IDs by walking `/sys/dev/char` and `/sys/class/drm`, which symlink into `/sys/devices`. Without `/sys`, that lookup finds nothing and the program falls back to software rendering even with `/dev/dri` present.
 - **Missing device is not an error.** If the host has no `/dev/dri` (no GPU, or running under a display manager without DRI), the bind is skipped silently and the sandbox launches normally, falling back to software rendering.
 - **macOS:** `sandbox-exec`'s policy model restricts syscalls by path, not by device node visibility, so GPU access on macOS is unaffected by sandboxing and `allowGpu` is a no-op there.
 
-> **Security note:** `/dev/dri` exposes the DRM render node, which on most systems is scoped to compute/rendering only (no display/mode-setting capability) and is the same node already reachable by any other unprivileged process in the host's `render` group. This is a materially smaller exposure than `allowNix = true`, but still widens the sandbox's device access beyond the default (no devices besides `/dev/null`, `/dev/zero`, `/dev/random`, etc.).
+> **Security note:** `allowGpu` exposes more than the GPU. The DRM render node itself is scoped to compute/rendering only (no display/mode-setting capability) and is already reachable by any other unprivileged process in the host's `render` group, but the read-only `/sys` bind additionally exposes the full host device and driver topology — every PCI/USB device, kernel module, and hardware identifier on the system — to the sandbox. That's read-only information disclosure, not a write or execution capability, and no broader than what any other unprivileged process on the host can already read from `/sys`, but it's a real widening of what the sandboxed agent can learn about the host beyond `allowNix = true`'s Nix-store exposure.
 
 ## Common patterns / recipes
 

--- a/lib/linux/default.nix
+++ b/lib/linux/default.nix
@@ -17,7 +17,9 @@
         /etc/ssl/certs   — TLS certificate verification
       Kernel filesystems:
         /proc   — mounted as a new procfs (only shows sandbox PIDs)
-        /dev    — minimal devtmpfs (null, zero, urandom, etc.)
+        /dev    — minimal devtmpfs (null, zero, urandom, etc.). When
+                  allowGpu is set, /dev/dri (DRM render + card nodes) is
+                  additionally dev-bound in from the host.
       Ephemeral tmpfs (empty, writable, lost on exit):
         /tmp    — scratch space
         $HOME   — prevents accidental reads of dotfiles; agent state
@@ -81,6 +83,14 @@
   outName,
   allowedPackages,
   allowNix ? false,
+  # If true, bind-mounts the host's /dev/dri (DRM render/card nodes) into
+  # the sandbox so GPU-dependent programs (e.g. a browser doing WebGL/GPU
+  # compositing) get hardware acceleration instead of falling back to
+  # software rendering. Requires the invoking host user to already have
+  # access to the render node (typically via membership in the "render" or
+  # "video" group) — bwrap does not grant new device permissions, it only
+  # makes an already-accessible device visible inside the sandbox.
+  allowGpu ? false,
   rwDirs ? [ ],
   rwFiles ? [ ],
   roDirs ? [ ],
@@ -120,6 +130,10 @@ let
     ::1       localhost
   '';
   pathStr = pkgs.lib.makeBinPath (allowedPackages ++ implicitPackages);
+  # dev-bind (not --bind) preserves device-node semantics; a plain bind
+  # would remount /dev/dri nodev and make them unopenable. -try skips it
+  # silently when the host has no GPU rather than failing the launch.
+  gpuBwrapStr = if allowGpu then ''--dev-bind-try /dev/dri /dev/dri'' else "";
   # Adds each rwDir / roDir to the BOUND_PREFIXES shell array at runtime
   stateDirsBoundPrefixBashStr = builtins.concatStringsSep "\n" (
     map (dir: ''BOUND_PREFIXES+=("${dir}")'') rwDirs
@@ -362,6 +376,7 @@ builtins.seq
             --ro-bind ${emptyFile} /proc/cmdline \
             --ro-bind ${emptyFile} /proc/sys/kernel/random/boot_id \
             --dev /dev \
+            ${gpuBwrapStr} \
             --tmpfs /tmp \
             --tmpfs "$HOME" \
             $REPO_BIND \

--- a/lib/linux/default.nix
+++ b/lib/linux/default.nix
@@ -127,19 +127,10 @@ let
     ::1       localhost
   '';
   pathStr = pkgs.lib.makeBinPath (allowedPackages ++ implicitPackages);
-  # dev-bind (not --bind) preserves device-node semantics; a plain bind
-  # would remount /dev/dri nodev and make them unopenable. -try skips it
-  # silently when the host has no GPU rather than failing the launch.
-  # /sys is also needed: libdrm's device enumeration (used by Mesa and by
-  # Chromium's own GPU info collector) resolves a DRM fd to its PCI vendor
-  # device IDs via /sys/dev/char/<major>:<minor> and /sys/class/drm, which
-  # both chain through symlinks into /sys/devices. Without it, GPU
-  # detection finds nothing and falls back to software rendering even
-  # though /dev/dri itself is reachable. This is read-only and exposes the
-  # full host device/driver topology (not just the GPU) to the sandbox —
-  # a real information disclosure, though not a write or execution
-  # capability, and no broader than what any other unprivileged process on
-  # the host can already read from /sys.
+  # dev-bind (not --bind) preserves device-node semantics so /dev/dri stays
+  # usable; -try skips it silently when the host has no GPU. /sys is also
+  # bound so GPU detection can resolve the device, at the cost of exposing
+  # the full host device topology read-only.
   gpuBwrapStr =
     if allowGpu then ''--dev-bind-try /dev/dri /dev/dri --ro-bind-try /sys /sys'' else "";
   # Adds each rwDir / roDir to the BOUND_PREFIXES shell array at runtime

--- a/lib/linux/default.nix
+++ b/lib/linux/default.nix
@@ -83,13 +83,10 @@
   outName,
   allowedPackages,
   allowNix ? false,
-  # If true, bind-mounts the host's /dev/dri (DRM render/card nodes) into
-  # the sandbox so GPU-dependent programs (e.g. a browser doing WebGL/GPU
-  # compositing) get hardware acceleration instead of falling back to
-  # software rendering. Requires the invoking host user to already have
-  # access to the render node (typically via membership in the "render" or
-  # "video" group) — bwrap does not grant new device permissions, it only
-  # makes an already-accessible device visible inside the sandbox.
+  # If true, bind-mounts the host's /dev/dri into the sandbox for
+  # hardware-accelerated GPU access. Requires the host user to already be
+  # in the "render" or "video" group — this only exposes the device, it
+  # doesn't grant new permissions.
   allowGpu ? false,
   rwDirs ? [ ],
   rwFiles ? [ ],

--- a/lib/linux/default.nix
+++ b/lib/linux/default.nix
@@ -130,7 +130,18 @@ let
   # dev-bind (not --bind) preserves device-node semantics; a plain bind
   # would remount /dev/dri nodev and make them unopenable. -try skips it
   # silently when the host has no GPU rather than failing the launch.
-  gpuBwrapStr = if allowGpu then ''--dev-bind-try /dev/dri /dev/dri'' else "";
+  # /sys is also needed: libdrm's device enumeration (used by Mesa and by
+  # Chromium's own GPU info collector) resolves a DRM fd to its PCI vendor
+  # device IDs via /sys/dev/char/<major>:<minor> and /sys/class/drm, which
+  # both chain through symlinks into /sys/devices. Without it, GPU
+  # detection finds nothing and falls back to software rendering even
+  # though /dev/dri itself is reachable. This is read-only and exposes the
+  # full host device/driver topology (not just the GPU) to the sandbox —
+  # a real information disclosure, though not a write or execution
+  # capability, and no broader than what any other unprivileged process on
+  # the host can already read from /sys.
+  gpuBwrapStr =
+    if allowGpu then ''--dev-bind-try /dev/dri /dev/dri --ro-bind-try /sys /sys'' else "";
   # Adds each rwDir / roDir to the BOUND_PREFIXES shell array at runtime
   stateDirsBoundPrefixBashStr = builtins.concatStringsSep "\n" (
     map (dir: ''BOUND_PREFIXES+=("${dir}")'') rwDirs

--- a/tests/fixtures/gpu-support.nix
+++ b/tests/fixtures/gpu-support.nix
@@ -1,0 +1,18 @@
+let
+  pkgs = import <nixpkgs> { };
+  sandbox = import ../../default.nix { pkgs = pkgs; };
+in {
+  withGpu = sandbox.mkSandbox {
+    pkg = pkgs.bashInteractive;
+    binName = "bash";
+    outName = "sandboxed-bash-gpu-allowed";
+    allowedPackages = [ pkgs.coreutils ];
+    allowGpu = true;
+  };
+  withoutGpu = sandbox.mkSandbox {
+    pkg = pkgs.bashInteractive;
+    binName = "bash";
+    outName = "sandboxed-bash-gpu-denied";
+    allowedPackages = [ pkgs.coreutils ];
+  };
+}

--- a/tests/linux/test-gpu-support.sh
+++ b/tests/linux/test-gpu-support.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../lib.sh"
+
+GPU_ALLOWED=$(nix-build --no-out-link -A withGpu "$SCRIPT_DIR/../fixtures/gpu-support.nix")
+GPU_ALLOWED_SHELL="$GPU_ALLOWED/bin/sandboxed-bash-gpu-allowed"
+
+GPU_DENIED=$(nix-build --no-out-link -A withoutGpu "$SCRIPT_DIR/../fixtures/gpu-support.nix")
+GPU_DENIED_SHELL="$GPU_DENIED/bin/sandboxed-bash-gpu-denied"
+
+echo "=== GPU support tests (Linux) ==="
+echo
+
+run() { "$GPU_ALLOWED_SHELL" --norc --noprofile -c "$@" >/dev/null 2>&1; }
+
+expect_ok "sandbox launches with allowGpu, whether or not the host has a GPU" \
+    'true'
+
+if [ -e /dev/dri ]; then
+    expect_ok "/dev/dri is visible inside the sandbox with allowGpu" \
+        '[ -e /dev/dri ]'
+
+    run() { "$GPU_DENIED_SHELL" --norc --noprofile -c "$@" >/dev/null 2>&1; }
+    expect_fail "/dev/dri is not visible inside the sandbox without allowGpu" \
+        '[ -e /dev/dri ]'
+else
+    echo "SKIP: host has no /dev/dri — skipping device-visibility assertions"
+fi
+
+print_results
+exit_status

--- a/tests/linux/test-gpu-support.sh
+++ b/tests/linux/test-gpu-support.sh
@@ -20,10 +20,14 @@ expect_ok "sandbox launches with allowGpu, whether or not the host has a GPU" \
 if [ -e /dev/dri ]; then
     expect_ok "/dev/dri is visible inside the sandbox with allowGpu" \
         '[ -e /dev/dri ]'
+    expect_ok "/sys/class/drm is visible inside the sandbox with allowGpu" \
+        '[ -e /sys/class/drm ]'
 
     run() { "$GPU_DENIED_SHELL" --norc --noprofile -c "$@" >/dev/null 2>&1; }
     expect_fail "/dev/dri is not visible inside the sandbox without allowGpu" \
         '[ -e /dev/dri ]'
+    expect_fail "/sys is not visible inside the sandbox without allowGpu" \
+        '[ -e /sys ]'
 else
     echo "SKIP: host has no /dev/dri — skipping device-visibility assertions"
 fi


### PR DESCRIPTION
## Summary

`allowGpu` (Linux) bind-mounts the host's `/dev/dri` and `/sys` into the sandbox for hardware-accelerated GPU access. Without it, GPU-dependent programs (browsers doing WebGL, video codecs, ML inference) silently fall back to software rendering.

Verified end-to-end against a real headless Chromium: with this change plus the right userspace driver env vars, `chrome://gpu` reports real hardware — `VENDOR=0x8086 (Intel)`, `DEVICE=0x1916 (HD Graphics 520)`, `DRIVER_VENDOR=Mesa`, and WebGL/Canvas/Compositing/Rasterization/Video Decode all "Hardware accelerated".

## Implementation

- `lib/linux/default.nix`: new `allowGpu ? false` arg. Emits `--dev-bind-try /dev/dri /dev/dri --ro-bind-try /sys /sys` right after `--dev /dev`.
  - `--dev-bind`, not `--bind`: a plain bind remounts `nodev`, which makes the device nodes unopenable. Flatpak uses the same approach for `--device=dri`.
  - `/sys` is required too, not just `/dev/dri`. Mesa's libdrm and Chromium's own GPU info collector both resolve a DRM device's PCI vendor/device IDs by walking `/sys/dev/char/<major>:<minor>` and `/sys/class/drm`, which symlink into `/sys/devices`. Without `/sys`, that lookup finds nothing and the program falls back to software rendering even with `/dev/dri` correctly bound.
  - `-try` skips the binds silently when the host has no GPU.
  - Both binds expose already-accessible resources; neither grants new permissions. `/dev/dri` still needs `render`/`video` group membership (verified this holds through nested unprivileged user namespaces). `/sys` is read-only but does expose the full host device/driver topology — a real, larger disclosure than `/dev/dri` alone, documented in the README's security note.
- Darwin is unaffected: `sandbox-exec` restricts by syscall/path, not device visibility.
- `tests/fixtures/gpu-support.nix` + `tests/linux/test-gpu-support.sh`: asserts the sandbox launches with `allowGpu` regardless of host GPU, and that `/dev/dri`/`/sys/class/drm` are visible with it and absent without it when the host has a GPU.
- `README.md`: documents both binds and the security tradeoff.