### PR TITLE
fix(darwin): add the session tmpdir to the AF_UNIX socket scope

### DIFF
--- a/launcher/lib/launch_config/darwin/compute.py
+++ b/launcher/lib/launch_config/darwin/compute.py
@@ -100,14 +100,18 @@ class _UnixSocketScope:
 
 
 def _get_unix_socket_scope(
-    host: HostStateDarwin, repo_root: Path | None
+    host: HostStateDarwin, repo_root: Path | None, sandbox_tmpdir: Path
 ) -> _UnixSocketScope:
     # The repository root joins the connect set: build servers keep their
     # rendezvous sockets at the build root (.bsp, .bloop, nailgun), not the
     # module directory the agent was launched in. It arrives already gated by
     # get_grantable_repo_root, so at a work tree root there is nothing to add:
     # the build root is the launch directory, which is in `writable` below.
-    writable = [host.cwd]
+    #
+    # The session tmpdir joins the bind set: tools create their IPC sockets
+    # under $TMPDIR. The directory is sandbox-private, so no host listener
+    # can live there.
+    writable = [host.cwd, sandbox_tmpdir]
     for declared in host.declared:
         if isinstance(declared, DeclaredDir) and declared.mode == "rw":
             writable.append(declared.expanded_path)
@@ -208,7 +212,7 @@ def _get_profile_lines(
     # unix-socket deny by last-match. Before nix_support, so the nested-ro
     # denies can never shadow the daemon socket allow.
     if spec.allow_unix_sockets:
-        scope = _get_unix_socket_scope(host, repo_root)
+        scope = _get_unix_socket_scope(host, repo_root, session.sandbox_tmpdir)
         lines += seatbelt.unix_sockets(
             scope.writable,
             scope.connect_dirs,

--- a/tests/darwin/test-unix-socket-allowed.sh
+++ b/tests/darwin/test-unix-socket-allowed.sh
@@ -5,8 +5,9 @@
 # different mechanisms: additive over deny-default in filtered mode,
 # outranking the blanket unix-socket deny by last-match in open mode. A
 # third variant asserts the ro semantics inside the writable scope: connect
-# works, bind is denied (issue #84). Flag-off behaviour is covered by
-# test-unix-socket-egress-denied.sh.
+# works, bind is denied (issue #84). The session TMPDIR is part of the bind
+# scope: tools create their IPC sockets under $TMPDIR. Flag-off behaviour
+# is covered by test-unix-socket-egress-denied.sh.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -41,6 +42,18 @@ run_open() {
 }
 run_nested() {
 	(cd "$TESTDIR" && "$SANDBOXED_NESTED/bin/sandboxed-bash" --norc --noprofile -c "$1") >/dev/null 2>&1
+}
+
+# For the TMPDIR checks: a short sessions root keeps the session tmpdir's
+# socket paths inside the sun_path budget (see the note above).
+SESS_ROOT=$(mktemp -d /private/tmp/uxsock-sess.XXXXXX)
+run_filtered_sess() {
+	(cd "$TESTDIR" && AGENT_SANDBOX_SESSIONS_ROOT="$SESS_ROOT" \
+		"$SANDBOXED_FILTERED/bin/sandboxed-bash" --norc --noprofile -c "$1") >/dev/null 2>&1
+}
+run_open_sess() {
+	(cd "$TESTDIR" && AGENT_SANDBOX_SESSIONS_ROOT="$SESS_ROOT" \
+		"$SANDBOXED_OPEN/bin/sandboxed-bash" --norc --noprofile -c "$1") >/dev/null 2>&1
 }
 
 # Declared paths OUTSIDE the launch dir, for the per-mode semantics: rw
@@ -85,6 +98,24 @@ cli.sendall(b\"x\")
 assert conn.recv(1) == b\"x\"
 "'
 
+# The same round-trip on a socket under the session TMPDIR.
+IN_TMPDIR_CHECK='python3 -c "
+import socket, os
+path = os.path.join(os.environ[\"TMPDIR\"], \"t.sock\")
+try:
+    os.unlink(path)
+except FileNotFoundError:
+    pass
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(path)
+srv.listen(1)
+cli = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+cli.connect(path)
+conn, _ = srv.accept()
+cli.sendall(b\"x\")
+assert conn.recv(1) == b\"x\"
+"'
+
 LISTENER_PIDS=""
 cleanup() {
 	if [ -n "$LISTENER_PIDS" ]; then
@@ -93,7 +124,7 @@ cleanup() {
 		# shellcheck disable=SC2086
 		wait $LISTENER_PIDS 2>/dev/null || true
 	fi
-	rm -rf "$SOCK_DIR" "$TESTDIR" "$RW_DIR" "$RO_DIR" "$RO_FILE_DIR" "$REPO"
+	rm -rf "$SOCK_DIR" "$TESTDIR" "$RW_DIR" "$RO_DIR" "$RO_FILE_DIR" "$REPO" "$SESS_ROOT"
 }
 trap cleanup EXIT
 
@@ -169,6 +200,11 @@ expect_ok run_filtered "socat binary is available inside the sandbox" "command -
 
 expect_ok run_filtered "filtered: bind+connect a socket in CWD" "$IN_CWD_CHECK"
 expect_ok run_open "open: bind+connect a socket in CWD" "$IN_CWD_CHECK"
+
+# The session TMPDIR is writable and sandbox-private, so it is part of the
+# bind scope.
+expect_ok run_filtered_sess "filtered: bind+connect a socket in TMPDIR" "$IN_TMPDIR_CHECK"
+expect_ok run_open_sess "open: bind+connect a socket in TMPDIR" "$IN_TMPDIR_CHECK"
 
 # The scope must not leak: a host socket outside CWD + rwDirs stays denied
 # even with the flag on. printf sends a byte so socat really connect()s.


### PR DESCRIPTION
Pre !103 the tmpdir was RW bound for darwin which also applied to sockets created by some tools. This behavior was not ported to the session-private tmp dir and this PR should restore this. This should allow sockets spun up in $TMPDIR to work again.

Claude Below

allowUnixSockets grants bind in the launch directory and declared rwDirs, but not in the session tmpdir — the one place JVM build tools actually put their IPC sockets (sbt's server socket lands under XDG_RUNTIME_DIR || java.io.tmpdir, and #118 points java.io.tmpdir at the session tmpdir). The bind is denied and the tool waits forever for a server that never came up.

The original reason to keep temp directories out of the socket scope — host launchd listeners under /tmp (#92) — no longer applies: since #103 the session tmpdir is sandbox-private, so no host listener can live there. Add it to the writable (bind + connect) set and cover both network modes in the behavioural test, with a short sessions root to stay inside the sun_path budget.